### PR TITLE
Feature/friend request

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/FriendRequestStatus.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/constant/FriendRequestStatus.java
@@ -1,0 +1,7 @@
+package ch.uzh.ifi.hase.soprafs24.constant;
+
+public enum FriendRequestStatus {
+    PENDING,
+    ACCEPTED,
+    DENIED
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/FriendController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/FriendController.java
@@ -1,0 +1,73 @@
+package ch.uzh.ifi.hase.soprafs24.controller;
+
+import ch.uzh.ifi.hase.soprafs24.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.FriendDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.FriendRequestDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs24.service.FriendService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/friends")
+public class FriendController {
+
+    private final FriendService friendService;
+    private final DTOMapper mapper;
+
+    public FriendController(FriendService friendService, DTOMapper mapper) {
+        this.friendService = friendService;
+        this.mapper = mapper;
+    }
+
+    // GET /api/friends/requests - get incoming friend requests for the authenticated user
+    @GetMapping("/requests")
+    @ResponseStatus(HttpStatus.OK)
+    public List<FriendRequestDTO> getFriendRequests(@RequestHeader("Authorization") String token) {
+        List<FriendRequest> requests = friendService.getIncomingFriendRequests(token);
+        return requests.stream()
+                .map(mapper::toFriendRequestDTO)
+                .collect(Collectors.toList());
+    }
+
+    // POST /api/friends/request - send a friend request
+    @PostMapping("/request")
+    @ResponseStatus(HttpStatus.CREATED)
+    public FriendRequestDTO sendFriendRequest(@RequestHeader("Authorization") String token,
+                                              @RequestBody FriendRequestDTO requestDTO) {
+        FriendRequest request = friendService.sendFriendRequest(token, requestDTO.getRecipient());
+        return mapper.toFriendRequestDTO(request);
+    }
+
+    // PUT /api/friends/requests/{requestId} - respond to a friend request (accept or deny)
+    @PutMapping("/requests/{requestId}")
+    @ResponseStatus(HttpStatus.OK)
+    public FriendRequestDTO respondToFriendRequest(@RequestHeader("Authorization") String token,
+                                                   @PathVariable Long requestId,
+                                                   @RequestBody FriendRequestDTO requestDTO) {
+        FriendRequest request = friendService.respondToFriendRequest(token, requestId, requestDTO.getAction());
+        return mapper.toFriendRequestDTO(request);
+    }
+    
+    // GET /api/friends - list friends for the authenticated user
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<FriendDTO> listFriends(@RequestHeader("Authorization") String token) {
+        List<User> friends = friendService.getFriends(token);
+        return friends.stream()
+                .map(mapper::toFriendDTO)
+                .collect(Collectors.toList());
+    }
+
+    // DELETE /api/friends/{friendId} - Unfriend a user.
+    @DeleteMapping("/{friendId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void unfriend(@RequestHeader("Authorization") String token,
+                     @PathVariable Long friendId) {
+    friendService.unfriend(token, friendId);
+}
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/FriendRequest.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/FriendRequest.java
@@ -31,13 +31,15 @@ public class FriendRequest {
     private Instant createdAt;
 
     @PrePersist
-    protected void onCreate() {
+    public void onCreate() {
         this.createdAt = Instant.now();
         this.status = FriendRequestStatus.PENDING;
     }
 
     // Getters and setters
-
+    public void setId(Long id) {
+        this.id = id;
+    }
     public Long getId() {
         return id;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/FriendRequest.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/FriendRequest.java
@@ -1,0 +1,65 @@
+package ch.uzh.ifi.hase.soprafs24.entity;
+
+import ch.uzh.ifi.hase.soprafs24.constant.FriendRequestStatus;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "friend_request")
+public class FriendRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // The user who sent the request
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "sender_id")
+    private User sender;
+
+    // The user who is to receive the request
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "recipient_id")
+    private User recipient;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FriendRequestStatus status;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+        this.status = FriendRequestStatus.PENDING;
+    }
+
+    // Getters and setters
+
+    public Long getId() {
+        return id;
+    }
+    public User getSender() {
+        return sender;
+    }
+    public void setSender(User sender) {
+        this.sender = sender;
+    }
+    public User getRecipient() {
+        return recipient;
+    }
+    public void setRecipient(User recipient) {
+        this.recipient = recipient;
+    }
+    public FriendRequestStatus getStatus() {
+        return status;
+    }
+    public void setStatus(FriendRequestStatus status) {
+        this.status = status;
+    }
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Friendship.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Friendship.java
@@ -1,0 +1,52 @@
+package ch.uzh.ifi.hase.soprafs24.entity;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "friendship")
+public class Friendship {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // One friend
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user1_id")
+    private User user1;
+
+    // The other friend
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user2_id")
+    private User user2;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+    }
+
+    // Getters and setters
+
+    public Long getId() {
+        return id;
+    }
+    public User getUser1() {
+        return user1;
+    }
+    public void setUser1(User user1) {
+        this.user1 = user1;
+    }
+    public User getUser2() {
+        return user2;
+    }
+    public void setUser2(User user2) {
+        this.user2 = user2;
+    }
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/User.java
@@ -43,11 +43,15 @@ public class User implements Serializable {
     private UserProfile profile;
 
     @PrePersist
-    protected void onCreate() {
+    public void onCreate() {
         this.createdAt = Instant.now();
     }
 
     // Getters and setters
+
+    public void setId(Long id) {
+        this.id = id;
+    }
 
     public Long getId() {
         return id;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/FriendRequestRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/FriendRequestRepository.java
@@ -1,0 +1,15 @@
+package ch.uzh.ifi.hase.soprafs24.repository;
+
+import ch.uzh.ifi.hase.soprafs24.constant.FriendRequestStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+    // Find incoming friend requests for a recipient that are still pending
+    List<FriendRequest> findByRecipientAndStatus(User recipient, FriendRequestStatus status);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/FriendshipRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/FriendshipRepository.java
@@ -1,0 +1,13 @@
+package ch.uzh.ifi.hase.soprafs24.repository;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Friendship;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+    Optional<Friendship> findByUser1AndUser2(User user1, User user2);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/FriendDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/FriendDTO.java
@@ -1,0 +1,20 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+public class FriendDTO {
+    private Long friendId;
+    private String username;
+
+    public Long getFriendId() {
+        return friendId;
+    }
+    public void setFriendId(Long friendId) {
+        this.friendId = friendId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/FriendRequestDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/FriendRequestDTO.java
@@ -1,0 +1,34 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+public class FriendRequestDTO {
+    // For sending a friend request, we need the recipient's user id.
+    private Long recipient;
+
+    // For responding to a request, we need an action: "accept" or "deny".
+    private String action;
+
+    // Optionally, include the request id when returning data.
+    private Long requestId;
+
+    // And you might include sender/recipient info in responses.
+    // Getters and setters
+
+    public Long getRecipient() {
+        return recipient;
+    }
+    public void setRecipient(Long recipient) {
+        this.recipient = recipient;
+    }
+    public String getAction() {
+        return action;
+    }
+    public void setAction(String action) {
+        this.action = action;
+    }
+    public Long getRequestId() {
+        return requestId;
+    }
+    public void setRequestId(Long requestId) {
+        this.requestId = requestId;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -1,19 +1,12 @@
 package ch.uzh.ifi.hase.soprafs24.rest.mapper;
 
-import java.util.ArrayList;
-
-import org.springframework.stereotype.Component;
-
+import ch.uzh.ifi.hase.soprafs24.entity.FriendRequest;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.entity.UserProfile;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserLoginResponseDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserMeDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserPublicDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserRegisterRequestDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserRegisterResponseDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserStatsDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserUpdateRequestDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserUpdateResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.*;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
 
 @Component
 public class DTOMapper {
@@ -23,7 +16,7 @@ public class DTOMapper {
         User user = new User();
         user.setEmail(dto.getEmail());
         user.setPassword(dto.getPassword());
-        
+
         // Default status assigned in service or here
         user.setStatus(ch.uzh.ifi.hase.soprafs24.constant.UserStatus.OFFLINE);
 
@@ -74,8 +67,9 @@ public class DTOMapper {
         dto.setUsername(user.getProfile().getUsername());
         dto.setMmr(user.getProfile().getMmr());
         dto.setAchievements(user.getProfile().getAchievements());
-        return dto;}
-        
+        return dto;
+    }
+
     // 5) Update Profile
     public void updateEntityFromDTO(User user, UserUpdateRequestDTO dto) {
         user.getProfile().setUsername(dto.getUsername());
@@ -84,6 +78,7 @@ public class DTOMapper {
             user.getProfile().setStatsPublic(dto.getStatsPublic());
         }
     }
+
 
     public UserUpdateResponseDTO toUpdateResponse(User user) {
         UserUpdateResponseDTO dto = new UserUpdateResponseDTO();
@@ -99,6 +94,25 @@ public class DTOMapper {
         dto.setGamesPlayed(user.getProfile().getGamesPlayed());
         dto.setWins(user.getProfile().getWins());
         dto.setMmr(user.getProfile().getMmr());
+        return dto;
+    }
+
+    // 7) Friend requests
+    public FriendRequestDTO toFriendRequestDTO(FriendRequest request) {
+        FriendRequestDTO dto = new FriendRequestDTO();
+        dto.setRequestId(request.getId());
+        dto.setRecipient(request.getRecipient().getId());
+        // You might include the action/status as a string in the DTO:
+        dto.setAction(request.getStatus().name().toLowerCase());
+        return dto;
+    }
+
+    // 8) friend requests
+
+    public FriendDTO toFriendDTO(User user) {
+        FriendDTO dto = new FriendDTO();
+        dto.setFriendId(user.getId());
+        dto.setUsername(user.getProfile().getUsername());
         return dto;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/FriendService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/FriendService.java
@@ -1,0 +1,143 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.constant.FriendRequestStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs24.entity.Friendship;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.FriendRequestRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.FriendshipRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+public class FriendService {
+
+    private final Logger log = LoggerFactory.getLogger(FriendService.class);
+
+    private final FriendRequestRepository friendRequestRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final UserRepository userRepository;
+    private final AuthService authService;
+
+    public FriendService(FriendRequestRepository friendRequestRepository,
+                         FriendshipRepository friendshipRepository,
+                         UserRepository userRepository,
+                         AuthService authService) {
+        this.friendRequestRepository = friendRequestRepository;
+        this.friendshipRepository = friendshipRepository;
+        this.userRepository = userRepository;
+        this.authService = authService;
+    }
+
+    // List incoming friend requests for the authenticated user.
+    public List<FriendRequest> getIncomingFriendRequests(String token) {
+        User recipient = authService.getUserByToken(token);
+        return friendRequestRepository.findByRecipientAndStatus(recipient, FriendRequestStatus.PENDING);
+    }
+
+    // Send a friend request from the authenticated user to a recipient.
+    public FriendRequest sendFriendRequest(String token, Long recipientId) {
+        User sender = authService.getUserByToken(token);
+        User recipient = userRepository.findById(recipientId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Recipient not found"));
+
+        // Check that a request doesn't already exist.
+        // (You could add more checks here if needed.)
+        FriendRequest request = new FriendRequest();
+        request.setSender(sender);
+        request.setRecipient(recipient);
+        // Status and createdAt are set via @PrePersist.
+        friendRequestRepository.save(request);
+        log.debug("Friend request sent from {} to {}", sender.getId(), recipient.getId());
+        return request;
+    }
+
+    // Accept or deny a friend request.
+    public FriendRequest respondToFriendRequest(String token, Long requestId, String action) {
+        // Only the recipient can respond.
+        User recipient = authService.getUserByToken(token);
+        FriendRequest request = friendRequestRepository.findById(requestId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Friend request not found"));
+
+        if (!request.getRecipient().getId().equals(recipient.getId())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authorized to respond to this friend request");
+        }
+
+        if ("accept".equalsIgnoreCase(action)) {
+            request.setStatus(FriendRequestStatus.ACCEPTED);
+            // Create a Friendship record.
+            Friendship friendship = new Friendship();
+            friendship.setUser1(request.getSender());
+            friendship.setUser2(request.getRecipient());
+            friendshipRepository.save(friendship);
+            log.debug("Friend request {} accepted", requestId);
+        } else if ("deny".equalsIgnoreCase(action)) {
+            request.setStatus(FriendRequestStatus.DENIED);
+            log.debug("Friend request {} denied", requestId);
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid action");
+        }
+
+        friendRequestRepository.save(request);
+        return request;
+    }
+    
+    // list all friends
+    public List<User> getFriends(String token) {
+        User currentUser = authService.getUserByToken(token);
+        // For demonstration, we retrieve all friendships and filter them.
+        // In production, consider writing a custom query to fetch only relevant friendships.
+        List<Friendship> allFriendships = friendshipRepository.findAll();
+        List<User> friends = new ArrayList<>();
+        
+        for (Friendship fs : allFriendships) {
+            if (fs.getUser1().getId().equals(currentUser.getId())) {
+                friends.add(fs.getUser2());
+            } else if (fs.getUser2().getId().equals(currentUser.getId())) {
+                friends.add(fs.getUser1());
+            }
+        }
+        
+        return friends;
+    }
+
+
+    //remove friend
+    public void unfriend(String token, Long friendId) {
+
+        User currentUser = authService.getUserByToken(token);
+        
+
+
+        List<Friendship> allFriendships = friendshipRepository.findAll();
+        Friendship friendshipToRemove = null;
+        
+        for (Friendship fs : allFriendships) {
+            if (fs.getUser1().getId().equals(currentUser.getId()) && fs.getUser2().getId().equals(friendId)) {
+                friendshipToRemove = fs;
+                break;
+            } else if (fs.getUser2().getId().equals(currentUser.getId()) && fs.getUser1().getId().equals(friendId)) {
+                friendshipToRemove = fs;
+                break;
+            }
+        }
+        
+        if (friendshipToRemove == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Friendship not found");
+        }
+        
+
+        friendshipRepository.delete(friendshipToRemove);
+        friendshipRepository.flush();
+        log.debug("Friendship between user {} and friend {} has been removed", currentUser.getId(), friendId);
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/FriendControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/FriendControllerTest.java
@@ -1,0 +1,140 @@
+package ch.uzh.ifi.hase.soprafs24.controller;
+
+import ch.uzh.ifi.hase.soprafs24.constant.FriendRequestStatus;
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.FriendDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.FriendRequestDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs24.service.FriendService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FriendController.class)
+public class FriendControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FriendService friendService;
+
+    @MockBean
+    private DTOMapper mapper;
+
+    private FriendRequestDTO friendRequestDTO;
+    private FriendRequest friendRequest;
+    private FriendDTO friendDTO;
+    private User user;
+    private List<FriendRequest> friendRequests;
+    private List<FriendDTO> friends;
+
+    @BeforeEach
+    void setUp() {
+        // Initialize FriendRequestDTO
+        friendRequestDTO = new FriendRequestDTO();
+        friendRequestDTO.setRecipient(2L); // Recipient user ID
+        friendRequestDTO.setAction("accept");
+
+        // Initialize FriendRequest
+        friendRequest = new FriendRequest();
+        friendRequest.setStatus(FriendRequestStatus.PENDING);
+
+        // Initialize FriendDTO
+        friendDTO = new FriendDTO();
+        friendDTO.setFriendId(1L);
+        friendDTO.setUsername("friendUsername");
+
+        // Initialize User
+        user = new User();
+        user.setEmail("userEmail@example.com");
+        user.setPassword("password");
+        user.setStatus(UserStatus.ONLINE);
+        user.setCreatedAt(Instant.now());
+
+        // Initialize lists for collections
+        friendRequests = new ArrayList<>();
+        friendRequests.add(friendRequest);
+
+        friends = new ArrayList<>();
+        friends.add(friendDTO);
+    }
+
+    @Test
+    public void getFriendRequests_ShouldReturnIncomingFriendRequests() throws Exception {
+        when(friendService.getIncomingFriendRequests("token")).thenReturn(friendRequests);
+        when(mapper.toFriendRequestDTO(friendRequest)).thenReturn(friendRequestDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/friends/requests")
+                        .header("Authorization", "token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].recipient").value(2)); // Verify recipient ID
+    }
+
+    @Test
+    public void sendFriendRequest_ShouldSendFriendRequestAndReturnCreated() throws Exception {
+        when(friendService.sendFriendRequest("token", 2L)).thenReturn(friendRequest);
+        when(mapper.toFriendRequestDTO(friendRequest)).thenReturn(friendRequestDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/friends/request")
+                        .header("Authorization", "token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"recipient\":2}")) // Use recipient user ID
+                .andExpect(status().isCreated())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.recipient").value(2)); // Verify recipient ID
+    }
+
+    @Test
+    public void respondToFriendRequest_ShouldRespondToFriendRequestAndReturnOk() throws Exception {
+        when(friendService.respondToFriendRequest("token", 1L, "accept")).thenReturn(friendRequest);
+        when(mapper.toFriendRequestDTO(friendRequest)).thenReturn(friendRequestDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/friends/requests/1")
+                        .header("Authorization", "token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"action\":\"accept\"}"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.recipient").value(2)); // Verify recipient ID
+    }
+
+    @Test
+    public void listFriends_ShouldReturnListOfFriends() throws Exception {
+        when(friendService.getFriends("token")).thenReturn(List.of(user));
+        when(mapper.toFriendDTO(user)).thenReturn(friendDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/friends")
+                        .header("Authorization", "token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$").isArray())
+                .andExpect(MockMvcResultMatchers.jsonPath("$[0].friendId").value(1)); // Verify friend ID
+    }
+
+    @Test
+    public void unfriend_ShouldUnfriendUserAndReturnNoContent() throws Exception {
+        doNothing().when(friendService).unfriend("token", 1L);
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/friends/1")
+                        .header("Authorization", "token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/FriendRepositoryTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/FriendRepositoryTest.java
@@ -1,0 +1,70 @@
+package ch.uzh.ifi.hase.soprafs24.repository;
+
+import ch.uzh.ifi.hase.soprafs24.constant.FriendRequestStatus;
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+public class FriendRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private FriendRequestRepository friendRequestRepository;
+
+    @BeforeEach
+    void setUp() {
+        // Create and persist sender and recipient users
+        User sender = new User();
+        sender.setEmail("sender@example.com");
+        sender.setPassword("password");
+        sender.setStatus(UserStatus.ONLINE);
+
+        User recipient = new User();
+        recipient.setEmail("recipient@example.com");
+        recipient.setPassword("password");
+        recipient.setStatus(UserStatus.ONLINE);
+
+        entityManager.persist(sender);
+        entityManager.persist(recipient);
+        entityManager.flush();
+
+        // Create and persist a friend request
+        FriendRequest request = new FriendRequest();
+        request.setSender(sender);
+        request.setRecipient(recipient);
+        request.setStatus(FriendRequestStatus.PENDING);
+        request.onCreate();
+
+        entityManager.persist(request);
+        entityManager.flush();
+    }
+
+    @Test
+    public void findByRecipientAndStatus_success() {
+        // given
+        User recipient = entityManager.find(User.class, 2L); // Assuming recipient has ID 2
+        FriendRequestStatus status = FriendRequestStatus.PENDING;
+
+        // when
+        List<FriendRequest> foundRequests = friendRequestRepository.findByRecipientAndStatus(recipient, status);
+
+        // then
+        assertNotNull(foundRequests);
+        assertEquals(1, foundRequests.size());
+        assertEquals(recipient, foundRequests.get(0).getRecipient());
+        assertEquals(status, foundRequests.get(0).getStatus());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/FriendServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/FriendServiceTest.java
@@ -1,0 +1,299 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.constant.FriendRequestStatus;
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs24.entity.FriendRequest;
+import ch.uzh.ifi.hase.soprafs24.entity.Friendship;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.FriendRequestRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.FriendshipRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class FriendServiceTest {
+
+    @Mock
+    private FriendRequestRepository friendRequestRepository;
+
+    @Mock
+    private FriendshipRepository friendshipRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AuthService authService;
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getIncomingFriendRequests_ShouldReturnPendingRequests() {
+        // Arrange
+        User recipient = new User();
+        recipient.setEmail("recipient@example.com");
+        recipient.setPassword("password");
+        recipient.setStatus(UserStatus.ONLINE);
+
+        FriendRequest request = new FriendRequest();
+        request.setSender(new User());
+        request.setRecipient(recipient);
+        request.setStatus(FriendRequestStatus.PENDING);
+        request.onCreate();
+
+        List<FriendRequest> requests = new ArrayList<>();
+        requests.add(request);
+
+        when(authService.getUserByToken("token")).thenReturn(recipient);
+        when(friendRequestRepository.findByRecipientAndStatus(recipient, FriendRequestStatus.PENDING)).thenReturn(requests);
+
+        // Act
+        List<FriendRequest> result = friendService.getIncomingFriendRequests("token");
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals(FriendRequestStatus.PENDING, result.get(0).getStatus());
+        assertNotNull(result.get(0).getCreatedAt()); // Verify createdAt is set
+    }
+
+    @Test
+    void sendFriendRequest_ShouldCreateNewRequest() {
+        // Arrange
+        User sender = new User();
+        sender.setEmail("sender@example.com");
+        sender.setPassword("password");
+        sender.setStatus(UserStatus.ONLINE);
+
+        User recipient = new User();
+        recipient.setEmail("recipient@example.com");
+        recipient.setPassword("password");
+        recipient.setStatus(UserStatus.ONLINE);
+
+        when(authService.getUserByToken("token")).thenReturn(sender);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(recipient));
+
+        // Mock the save method to return the saved entity
+        when(friendRequestRepository.save(any(FriendRequest.class))).thenAnswer(invocation -> {
+            FriendRequest request = invocation.getArgument(0);
+            request.setStatus(FriendRequestStatus.PENDING); // Simulate the @PrePersist logic
+            return request;
+        });
+
+        // Act
+        FriendRequest result = friendService.sendFriendRequest("token", 2L);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(sender, result.getSender());
+        assertEquals(recipient, result.getRecipient());
+        assertEquals(FriendRequestStatus.PENDING, result.getStatus());
+        verify(friendRequestRepository, times(1)).save(any(FriendRequest.class));
+    }
+
+    @Test
+    void respondToFriendRequest_ShouldAcceptRequest() {
+        // Arrange
+        User recipient = new User();
+        recipient.setId(1L);
+        recipient.setEmail("recipient@example.com");
+        recipient.setPassword("password");
+        recipient.setStatus(UserStatus.ONLINE);
+
+        User sender = new User();
+        sender.setEmail("sender@example.com");
+        sender.setPassword("password");
+        sender.setStatus(UserStatus.ONLINE);
+
+        FriendRequest request = new FriendRequest();
+        request.setSender(sender);
+        request.setRecipient(recipient);
+        request.setStatus(FriendRequestStatus.PENDING);
+
+        // Mock the save method to return the saved entity with an ID
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            user.setId(1L); // Simulate the ID being set by the database
+            return user;
+        });
+
+        when(authService.getUserByToken("token")).thenReturn(recipient);
+        when(friendRequestRepository.findById(1L)).thenReturn(Optional.of(request));
+
+        // Act
+        FriendRequest result = friendService.respondToFriendRequest("token", 1L, "accept");
+
+        // Assert
+        assertEquals(FriendRequestStatus.ACCEPTED, result.getStatus());
+        verify(friendshipRepository, times(1)).save(any(Friendship.class));
+    }
+
+    @Test
+    void respondToFriendRequest_ShouldDenyRequest() {
+        // Arrange
+        User recipient = new User();
+        recipient.setId(1L);
+        recipient.onCreate();
+        recipient.setEmail("recipient@example.com");
+        recipient.setPassword("password");
+        recipient.setStatus(UserStatus.ONLINE);
+
+        User sender = new User();
+        sender.setEmail("sender@example.com");
+        sender.setPassword("password");
+        sender.setStatus(UserStatus.ONLINE);
+        sender.onCreate();
+
+        FriendRequest request = new FriendRequest();
+        request.setSender(sender);
+        request.setRecipient(recipient);
+        request.setStatus(FriendRequestStatus.PENDING);
+        request.onCreate();
+
+        when(authService.getUserByToken("token")).thenReturn(recipient);
+        when(friendRequestRepository.findById(1L)).thenReturn(Optional.of(request));
+
+        // Act
+        FriendRequest result = friendService.respondToFriendRequest("token", 1L, "deny");
+
+        // Assert
+        assertEquals(FriendRequestStatus.DENIED, result.getStatus());
+        assertNotNull(result.getCreatedAt()); // Verify createdAt is set
+    }
+
+    @Test
+    void respondToFriendRequest_ShouldThrowExceptionForInvalidAction() {
+        // Arrange
+        User recipient = new User();
+        recipient.setId(1L);
+        recipient.onCreate();
+        recipient.setEmail("recipient@example.com");
+        recipient.setPassword("password");
+        recipient.setStatus(UserStatus.ONLINE);
+
+        FriendRequest request = new FriendRequest();
+        request.onCreate();
+        request.setId(1L);
+        request.setRecipient(recipient);
+        request.setStatus(FriendRequestStatus.PENDING);
+
+        when(authService.getUserByToken("token")).thenReturn(recipient);
+        when(friendRequestRepository.findById(1L)).thenReturn(Optional.of(request));
+
+        // Act & Assert
+        assertThrows(ResponseStatusException.class, () -> friendService.respondToFriendRequest("token", 1L, "invalid"));
+    }
+
+    @Test
+    void getFriends_ShouldReturnListOfFriends() {
+        // Arrange
+        User currentUser = new User();
+        currentUser.setId(1L);
+        currentUser.onCreate();
+        currentUser.setEmail("current@example.com");
+        currentUser.setPassword("password");
+        currentUser.setStatus(UserStatus.ONLINE);
+
+        User friend1 = new User();
+        friend1.setId(2L);
+        friend1.onCreate();
+        friend1.setEmail("friend1@example.com");
+        friend1.setPassword("password");
+        friend1.setStatus(UserStatus.ONLINE);
+
+        User friend2 = new User();
+        friend2.setId(3L);
+        friend2.onCreate();
+        friend2.setEmail("friend2@example.com");
+        friend2.setPassword("password");
+        friend2.setStatus(UserStatus.ONLINE);
+
+        Friendship friendship1 = new Friendship();
+        friendship1.setUser1(currentUser);
+        friendship1.setUser2(friend1);
+
+        Friendship friendship2 = new Friendship();
+        friendship2.setUser1(friend2);
+        friendship2.setUser2(currentUser);
+
+        List<Friendship> friendships = new ArrayList<>();
+        friendships.add(friendship1);
+        friendships.add(friendship2);
+
+        when(authService.getUserByToken("token")).thenReturn(currentUser);
+        when(friendshipRepository.findAll()).thenReturn(friendships);
+
+        // Act
+        List<User> friends = friendService.getFriends("token");
+
+        // Assert
+        assertEquals(2, friends.size());
+        assertTrue(friends.contains(friend1));
+        assertTrue(friends.contains(friend2));
+    }
+
+    @Test
+    void unfriend_ShouldRemoveFriendship() {
+        // Arrange
+        User currentUser = new User();
+        currentUser.setId(1L);
+        currentUser.onCreate();
+        currentUser.setEmail("current@example.com");
+        currentUser.setPassword("password");
+        currentUser.setStatus(UserStatus.ONLINE);
+
+        User friend = new User();
+        friend.setId(2L);
+        friend.onCreate();
+        friend.setEmail("friend@example.com");
+        friend.setPassword("password");
+        friend.setStatus(UserStatus.ONLINE);
+
+        Friendship friendship = new Friendship();
+        friendship.setUser1(currentUser);
+        friendship.setUser2(friend);
+
+        List<Friendship> friendships = new ArrayList<>();
+        friendships.add(friendship);
+
+        when(authService.getUserByToken("token")).thenReturn(currentUser);
+        when(friendshipRepository.findAll()).thenReturn(friendships);
+        System.out.println(friend.getId());
+        // Act
+        friendService.unfriend("token", friend.getId());
+
+        // Assert
+        verify(friendshipRepository, times(1)).delete(friendship);
+    }
+
+    @Test
+    void unfriend_ShouldThrowExceptionIfFriendshipNotFound() {
+        // Arrange
+        User currentUser = new User();
+        currentUser.setEmail("current@example.com");
+        currentUser.setPassword("password");
+        currentUser.setStatus(UserStatus.ONLINE);
+
+        when(authService.getUserByToken("token")).thenReturn(currentUser);
+        when(friendshipRepository.findAll()).thenReturn(new ArrayList<>());
+
+        // Act & Assert
+        assertThrows(ResponseStatusException.class, () -> friendService.unfriend("token", 2L));
+    }
+}


### PR DESCRIPTION
### Related Issues

Closes #69 , Closes #75 , Closes #76  , Closes #77 , Closes #78 , Closes #79 

### Changes

Changes
1.Friend Request Handling

    Sending Friend Requests:

        -Users can now send friend requests using POST /api/friends/request.
        -The system ensures that duplicate friend requests are not created.
        -Requests are stored in the database with a PENDING status until accepted or denied.

    Receiving Friend Requests:

        -Users can retrieve their incoming friend requests via GET /api/friends/requests. 
        -Only PENDING friend requests are shown.

    Accepting or Denying Friend Requests:

        -Users can respond to friend requests with PUT /api/friends/requests/{requestId}.
        -If a request is accepted, a Friendship entity is created, and both users become friends. If a request is denied, the status is updated to DENIED.

2. Friendship Management

    Listing Friends:

        -Users can retrieve a list of their friends via GET /api/friends.

    Unfriending Users:

        -Users can remove friends using DELETE /api/friends/{friendId}. The friendship is deleted from the database, and both users are no longer connected.

3.General Improvements

Authorization Handling:

        -All operations require an authentication token to ensure security, and users can only manage their own friend requests and friendships.

Logging and Debugging:

        -Added logging for key actions like sending/accepting/denying friend requests and unfriending users.

4.Tests

FriendControllerTest: Ensures that the API endpoint returns the correct HTTP response and data format.

FriendRepositoryTest: Verifies that database queries are correct.

FriendServiceTest: Ensures that business logic is executed correctly, including friend request management and friend relationship maintenance.

