### PR TITLE
Feat/lobby websocket

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // WebSocket support
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework:spring-messaging'
+    
+    // WebSocket client libraries (optional)
+    implementation 'org.webjars:sockjs-client:1.5.1'
+    implementation 'org.webjars:stomp-websocket:2.3.4'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,122 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>ch.uzh.ifi.hase</groupId>
+    <artifactId>soprafs24</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>soprafs24</name>
+    <description>Sopra FS24 Group 15</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.5.4</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>11</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>sockjs-client</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>stomp-websocket</artifactId>
+            <version>2.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/config/WebSocketConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/config/WebSocketConfig.java
@@ -24,7 +24,6 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
-import org.springframework.web.socket.WebSocketSession;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 
@@ -42,12 +41,22 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        // Enable a simple in-memory broker for topics
-        config.enableSimpleBroker("/topic");
+        // Enable a simple in-memory broker with longer heartbeat intervals
+        config.enableSimpleBroker("/topic", "/queue")
+              .setHeartbeatValue(new long[] {10000, 10000}) // Increased heartbeat interval for stability
+              .setTaskScheduler(new org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler() {{
+                  setPoolSize(1);
+                  setThreadNamePrefix("websocket-heartbeat-thread-");
+                  initialize();
+              }});
+        
         // Set prefix for client-to-server messages
         config.setApplicationDestinationPrefixes("/app");
+        
         // Set prefix for user-specific messages
         config.setUserDestinationPrefix("/user");
+        
+        logger.info("Message broker configured with /topic, /app prefixes and 10s heartbeat");
     }
 
     @Override
@@ -57,6 +66,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             @Override
             public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
                     WebSocketHandler wsHandler, Map<String, Object> attributes) {
+                
+                logger.info("WebSocket handshake request received from: {}", request.getRemoteAddress());
                 
                 // Get Authorization header
                 List<String> authHeaders = request.getHeaders().get("Authorization");
@@ -83,6 +94,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                     // Store user information in attributes for later use
                     attributes.put("userId", user.getId());
                     attributes.put("username", user.getProfile().getUsername());
+                    attributes.put("token", token); // Store token for later use
                     
                     logger.info("WebSocket handshake authorized for user: {}", user.getId());
                     return true;
@@ -96,7 +108,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             @Override
             public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, 
                     WebSocketHandler wsHandler, Exception exception) {
-                // Nothing to do after handshake
+                if (exception != null) {
+                    logger.error("Error during WebSocket handshake: {}", exception.getMessage());
+                }
             }
         };
         
@@ -108,7 +122,20 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 
                 // Create and return a Principal based on the userId attribute
                 if (attributes.containsKey("userId")) {
-                    final Long userId = (Long) attributes.get("userId");
+                    // Fix type conversion issues with userId
+                    final Long userId;
+                    Object userIdObj = attributes.get("userId");
+                    
+                    if (userIdObj instanceof Integer) {
+                        userId = ((Integer) userIdObj).longValue();
+                    } else if (userIdObj instanceof Long) {
+                        userId = (Long) userIdObj;
+                    } else {
+                        userId = Long.valueOf(userIdObj.toString());
+                    }
+                    
+                    // Fix: Use concatenation instead of placeholder to avoid Throwable confusion
+                    logger.info("Creating principal for user: " + userId);
                     return new Principal() {
                         @Override
                         public String getName() {
@@ -121,18 +148,25 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             }
         };
         
+        logger.info("Registering STOMP endpoints: /ws/lobby, /ws/lobby-manager, /ws/user");
+        
         // Register endpoints with SockJS for browser clients
         registry.addEndpoint("/ws/lobby", "/ws/lobby-manager", "/ws/user")
-               .setAllowedOrigins("http://localhost:8000")
+               .setAllowedOrigins("*") // Allow from all origins (change as needed)
                .addInterceptors(authInterceptor)
                .setHandshakeHandler(handshakeHandler)
-               .withSockJS();
+               .withSockJS()
+               .setClientLibraryUrl("https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js")
+               .setWebSocketEnabled(true)
+               .setDisconnectDelay(5000); // Set disconnect delay for testing
         
         // Also register endpoints without SockJS for Postman testing
         registry.addEndpoint("/ws/lobby", "/ws/lobby-manager", "/ws/user")
                .setAllowedOrigins("*") // Allow from any origin for testing
                .addInterceptors(authInterceptor)
                .setHandshakeHandler(handshakeHandler);
+        
+        logger.info("STOMP endpoints registered successfully");
     }
 
     @Override
@@ -141,48 +175,128 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registration.interceptors(new ChannelInterceptor() {
             @Override
             public Message<?> preSend(Message<?> message, MessageChannel channel) {
-                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                
-                // Only authenticate on connect
-                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-                    // Extract the Authorization header
-                    List<String> authorization = accessor.getNativeHeader("Authorization");
-                    if (authorization != null && !authorization.isEmpty()) {
-                        String authHeader = authorization.get(0);
-                        String token = authHeader;
-                        
-                        // Handle both "Bearer token" format and raw token format
-                        if (authHeader.startsWith("Bearer ")) {
-                            token = authHeader.substring(7);
-                        }
-                        
-                        try {
-                            // Validate token and get user
-                            User user = authService.getUserByToken(token);
-                            
-                            // Set authenticated user as Principal
-                            accessor.setUser(new Principal() {
-                                @Override
-                                public String getName() {
-                                    return user.getId().toString();
-                                }
-                            });
-                            
-                            // Log successful authentication
-                            logger.info("WebSocket authentication successful for user ID: {}", user.getId());
-                        } catch (Exception e) {
-                            // Log authentication failure with reason
-                            logger.warn("WebSocket authentication failed: {}", e.getMessage());
-                            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid authentication token");
-                        }
-                    } else {
-                        // Log missing authorization header
-                        logger.warn("WebSocket connection attempt without authorization token");
-                        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No authorization token provided");
+                try {
+                    StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                    
+                    // Check for malformed messages
+                    if (accessor == null || accessor.getCommand() == null) {
+                        logger.error("Received malformed STOMP frame or non-STOMP message");
+                        // Return the message as-is - the framework will reject it with appropriate error
+                        return message;
                     }
+                    
+                    // Enhanced logging - log ALL messages for debugging
+                    logger.info("STOMP command received: {}, sessionId={}, payload={}", 
+                        accessor.getCommand(), accessor.getSessionId(), 
+                        message.getPayload() != null ? message.getPayload().toString() : "null");
+                    
+                    // Log all headers for debugging
+                    accessor.toNativeHeaderMap().forEach((key, value) -> {
+                        logger.info("STOMP header: {} = {}", key, value);
+                    });
+                    
+                    // Debug specific commands
+                    if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                        logger.info("Processing STOMP CONNECT frame");
+                        
+                        // Get token from handshake attributes if available
+                        String token = null;
+                        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+                        if (sessionAttributes != null && sessionAttributes.containsKey("token")) {
+                            token = (String)sessionAttributes.get("token");
+                            // Fix: Check token length before substring to avoid errors
+                            if (token.length() > 10) {
+                                logger.info("Using token from handshake: {}", token.substring(0, 10) + "...");
+                            } else {
+                                logger.info("Using token from handshake: {}", token);
+                            }
+                        }
+                        
+                        // Fall back to Authorization header if needed
+                        if (token == null) {
+                            List<String> authorization = accessor.getNativeHeader("Authorization");
+                            if (authorization != null && !authorization.isEmpty()) {
+                                String authHeader = authorization.get(0);
+                                token = authHeader;
+                                
+                                // Handle Bearer token format
+                                if (authHeader.startsWith("Bearer ")) {
+                                    token = authHeader.substring(7);
+                                }
+                                // Fix: Check token length before substring to avoid errors
+                                if (token.length() > 10) {
+                                    logger.info("Using token from STOMP headers: {}", token.substring(0, 10) + "...");
+                                } else {
+                                    logger.info("Using token from STOMP headers: {}", token);
+                                }
+                            }
+                        }
+                        
+                        // Validate token if found
+                        if (token != null) {
+                            try {
+                                User user = authService.getUserByToken(token);
+                                
+                                // Set authenticated user as Principal
+                                accessor.setUser(new Principal() {
+                                    @Override
+                                    public String getName() {
+                                        return user.getId().toString();
+                                    }
+                                });
+                                
+                                logger.info("STOMP authentication successful for user ID: {}", user.getId());
+                            } catch (Exception e) {
+                                logger.warn("STOMP authentication failed: {}", e.getMessage());
+                                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
+                            }
+                        } 
+                        // Use principal from handshake if already set
+                        else if (accessor.getUser() == null) {
+                            logger.warn("STOMP connection attempt without authorization");
+                            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No authorization provided");
+                        }
+                    } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+                        logger.info("STOMP SUBSCRIBE to: {}", accessor.getDestination());
+                    } else if (StompCommand.SEND.equals(accessor.getCommand())) {
+                        logger.info("STOMP SEND to: {}", accessor.getDestination());
+                    } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+                        logger.info("STOMP DISCONNECT from sessionId: {}", accessor.getSessionId());
+                    }
+                } catch (Exception e) {
+                    logger.error("Error processing STOMP frame: {}", e.getMessage(), e);
+                }
+                
+                return message;
+            }
+        });
+        
+        logger.info("Client inbound channel configured with authentication interceptor");
+    }
+
+    // Add outbound channel interceptor to debug CONNECTED responses
+    @Override
+    public void configureClientOutboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                try {
+                    StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                    if (accessor != null && accessor.getCommand() != null) {
+                        logger.info("OUTBOUND STOMP frame: command={}, sessionId={}, destination={}", 
+                            accessor.getCommand(), accessor.getSessionId(), accessor.getDestination());
+                        
+                        if (StompCommand.CONNECTED.equals(accessor.getCommand())) {
+                            logger.info("Sending CONNECTED response to client");
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.error("Error in outbound channel: {}", e.getMessage());
                 }
                 return message;
             }
         });
+        
+        logger.info("Client outbound channel configured with logging interceptor");
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/config/WebSocketConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/config/WebSocketConfig.java
@@ -1,0 +1,109 @@
+package ch.uzh.ifi.hase.soprafs24.config;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.service.AuthService;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketConfig.class);
+
+    @Autowired
+    private AuthService authService;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // Enable a simple in-memory broker for topics
+        config.enableSimpleBroker("/topic");
+        // Set prefix for client-to-server messages
+        config.setApplicationDestinationPrefixes("/app");
+        // Set prefix for user-specific messages
+        config.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // Register the WebSocket endpoints with SockJS for browser clients
+        registry.addEndpoint("/ws/lobby", "/ws/lobby-manager", "/ws/user")
+               .setAllowedOrigins("http://localhost:8000") 
+               .withSockJS();
+        
+        // Also register endpoints without SockJS for Postman testing
+        registry.addEndpoint("/ws/lobby", "/ws/lobby-manager", "/ws/user")
+               .setAllowedOrigins("*"); // Allow from any origin for testing
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // Add an interceptor to authenticate users via token
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                
+                // Only authenticate on connect
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    // Extract the Authorization header
+                    List<String> authorization = accessor.getNativeHeader("Authorization");
+                    if (authorization != null && !authorization.isEmpty()) {
+                        String authHeader = authorization.get(0);
+                        String token = authHeader;
+                        
+                        // Handle both "Bearer token" format and raw token format
+                        if (authHeader.startsWith("Bearer ")) {
+                            token = authHeader.substring(7);
+                        }
+                        
+                        try {
+                            // Validate token and get user
+                            User user = authService.getUserByToken(token);
+                            
+                            // Set authenticated user as Principal
+                            accessor.setUser(new Principal() {
+                                @Override
+                                public String getName() {
+                                    return user.getId().toString();
+                                }
+                            });
+                            
+                            // Log successful authentication
+                            logger.info("WebSocket authentication successful for user ID: {}", user.getId());
+                        } catch (Exception e) {
+                            // Log authentication failure with reason
+                            logger.warn("WebSocket authentication failed: {}", e.getMessage());
+                            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid authentication token");
+                        }
+                    } else {
+                        // Log missing authorization header
+                        logger.warn("WebSocket connection attempt without authorization token");
+                        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No authorization token provided");
+                    }
+                }
+                return message;
+            }
+        });
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/config/WebSocketConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/config/WebSocketConfig.java
@@ -18,9 +18,15 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
 
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.service.AuthService;
@@ -46,19 +52,92 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // Register the WebSocket endpoints with SockJS for browser clients
+        // Create a handshake interceptor to enforce token authentication
+        HandshakeInterceptor authInterceptor = new HandshakeInterceptor() {
+            @Override
+            public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                    WebSocketHandler wsHandler, Map<String, Object> attributes) {
+                
+                // Get Authorization header
+                List<String> authHeaders = request.getHeaders().get("Authorization");
+                
+                // Reject if no Authorization header
+                if (authHeaders == null || authHeaders.isEmpty()) {
+                    logger.warn("WebSocket handshake rejected: No Authorization header");
+                    response.setStatusCode(HttpStatus.UNAUTHORIZED);
+                    return false;
+                }
+                
+                String authHeader = authHeaders.get(0);
+                String token = authHeader;
+                
+                // Handle Bearer token format
+                if (authHeader.startsWith("Bearer ")) {
+                    token = authHeader.substring(7);
+                }
+                
+                try {
+                    // Validate token
+                    User user = authService.getUserByToken(token);
+                    
+                    // Store user information in attributes for later use
+                    attributes.put("userId", user.getId());
+                    attributes.put("username", user.getProfile().getUsername());
+                    
+                    logger.info("WebSocket handshake authorized for user: {}", user.getId());
+                    return true;
+                } catch (Exception e) {
+                    logger.warn("WebSocket handshake rejected: Invalid token - {}", e.getMessage());
+                    response.setStatusCode(HttpStatus.UNAUTHORIZED);
+                    return false;
+                }
+            }
+
+            @Override
+            public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, 
+                    WebSocketHandler wsHandler, Exception exception) {
+                // Nothing to do after handshake
+            }
+        };
+        
+        // Custom handshake handler with additional principal setup
+        DefaultHandshakeHandler handshakeHandler = new DefaultHandshakeHandler() {
+            @Override
+            protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler, 
+                    Map<String, Object> attributes) {
+                
+                // Create and return a Principal based on the userId attribute
+                if (attributes.containsKey("userId")) {
+                    final Long userId = (Long) attributes.get("userId");
+                    return new Principal() {
+                        @Override
+                        public String getName() {
+                            return userId.toString();
+                        }
+                    };
+                }
+                
+                return null; // This should not happen due to our interceptor check
+            }
+        };
+        
+        // Register endpoints with SockJS for browser clients
         registry.addEndpoint("/ws/lobby", "/ws/lobby-manager", "/ws/user")
-               .setAllowedOrigins("http://localhost:8000") 
+               .setAllowedOrigins("http://localhost:8000")
+               .addInterceptors(authInterceptor)
+               .setHandshakeHandler(handshakeHandler)
                .withSockJS();
         
         // Also register endpoints without SockJS for Postman testing
         registry.addEndpoint("/ws/lobby", "/ws/lobby-manager", "/ws/user")
-               .setAllowedOrigins("*"); // Allow from any origin for testing
+               .setAllowedOrigins("*") // Allow from any origin for testing
+               .addInterceptors(authInterceptor)
+               .setHandshakeHandler(handshakeHandler);
     }
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        // Add an interceptor to authenticate users via token
+        // Add an interceptor to authenticate users via token at STOMP level
         registration.interceptors(new ChannelInterceptor() {
             @Override
             public Message<?> preSend(Message<?> message, MessageChannel channel) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyController.java
@@ -57,7 +57,12 @@ public class LobbyController {
         Lobby lobby = mapper.lobbyRequestDTOToEntity(lobbyRequestDTO);
         lobby.setHost(currentUser);
         Lobby createdLobby = lobbyService.createLobby(lobby);
-        return mapper.lobbyEntityToResponseDTO(createdLobby);
+        LobbyResponseDTO responseDTO = mapper.lobbyEntityToResponseDTO(createdLobby);
+        // Ensure we have roundCardsStartAmount set
+        if (responseDTO.getRoundCardsStartAmount() == null && createdLobby.getHintsEnabled() != null) {
+            responseDTO.setRoundCardsStartAmount(createdLobby.getHintsEnabled().size());
+        }
+        return responseDTO;
     }
 
     // Retrieve lobby details.

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LobbyResponseDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LobbyResponseDTO.java
@@ -8,15 +8,23 @@ public class LobbyResponseDTO {
     private Long lobbyId;
     private String mode;
     private boolean isPrivate;
+    // New field name as per requirements
+    private String code;
+    // For backward compatibility
     private String lobbyCode;
     
-    // Used for team mode only
-    private Integer maxPlayersPerTeam;
+    // Used for team mode only, renamed from maxPlayersPerTeam
+    private Integer playersPerTeam;
     
-    // Used for solo mode only
-    private Integer maxPlayers;
+    // Changed to String as per requirements
+    private String maxPlayers;
     
+    // New field for count of round cards instead of the list
+    private Integer roundCardsStartAmount;
+    
+    // Keep for backward compatibility
     private List<String> roundCards;
+    
     private Instant createdAt;
     private String status;
     
@@ -44,37 +52,66 @@ public class LobbyResponseDTO {
     public void setPrivate(boolean isPrivate) {
         this.isPrivate = isPrivate;
     }
+    
+    // New getter/setter for code
+    public String getCode() {
+        return code;
+    }
+    public void setCode(String code) {
+        this.code = code;
+    }
+    
+    // For backward compatibility
     public String getLobbyCode() {
-        return lobbyCode;
+        return code;
     }
     public void setLobbyCode(String lobbyCode) {
+        this.code = lobbyCode;
         this.lobbyCode = lobbyCode;
     }
     
-    // Only return maxPlayersPerTeam for team mode
-    public Integer getMaxPlayersPerTeam() {
-        return "team".equals(mode) ? maxPlayersPerTeam : null;
+    // Fix: Remove conditional check that was causing tests to fail
+    public Integer getPlayersPerTeam() {
+        return playersPerTeam;
     }
     
-    public void setMaxPlayersPerTeam(int maxPlayersPerTeam) {
-        this.maxPlayersPerTeam = maxPlayersPerTeam;
+    // Changed parameter type from primitive int to object Integer for consistency
+    public void setPlayersPerTeam(Integer playersPerTeam) {
+        this.playersPerTeam = playersPerTeam;
     }
     
-    // Only return maxPlayers for solo mode
-    public Integer getMaxPlayers() {
-        return "solo".equals(mode) ? maxPlayers : null;
+    // Changed to String
+    public String getMaxPlayers() {
+        return maxPlayers;
     }
     
-    public void setMaxPlayers(Integer maxPlayers) {
+    public void setMaxPlayers(String maxPlayers) {
         this.maxPlayers = maxPlayers;
     }
     
+    // For backward compatibility
+    public void setMaxPlayers(Integer maxPlayers) {
+        if (maxPlayers != null) {
+            this.maxPlayers = String.valueOf(maxPlayers);
+        }
+    }
+    
+    // New getter/setter for roundCardsStartAmount
+    public Integer getRoundCardsStartAmount() {
+        return roundCardsStartAmount;
+    }
+    public void setRoundCardsStartAmount(Integer roundCardsStartAmount) {
+        this.roundCardsStartAmount = roundCardsStartAmount;
+    }
+    
+    // Keep for backward compatibility
     public List<String> getRoundCards() {
         return roundCards;
     }
     public void setRoundCards(List<String> roundCards) {
         this.roundCards = roundCards;
     }
+    
     public Instant getCreatedAt() {
         return createdAt;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPublicDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPublicDTO.java
@@ -1,12 +1,14 @@
 package ch.uzh.ifi.hase.soprafs24.rest.dto;
-
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class UserPublicDTO {
     private Long userid;
     private String username;
     private int mmr;
     private int points;
+    @JsonIgnore
     private List<String> achievements;
     private String email;
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -96,6 +96,7 @@ public class DTOMapper {
         dto.setUsername(user.getProfile().getUsername());
         dto.setMmr(user.getProfile().getMmr());
         dto.setAchievements(user.getProfile().getAchievements());
+        dto.setEmail(user.getEmail());
         return dto;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -134,6 +134,22 @@ public class UserService {
     }
 
     /**
+     * Find a user by username
+     */
+    public User findByUsername(String username) {
+        if (username == null || username.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username cannot be empty");
+        }
+        
+        User user = userRepository.findByProfile_Username(username);
+        if (user == null) {
+            return null; // Return null to let the caller handle the not-found case
+        }
+        
+        return user;
+    }
+
+    /**
      * delete current user account
      */
     public void deleteMyAccount(String token, String password) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListener.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/WebSocketEventListener.java
@@ -1,0 +1,72 @@
+package ch.uzh.ifi.hase.soprafs24.websocket;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import ch.uzh.ifi.hase.soprafs24.websocket.dto.WebSocketMessage;
+
+@Component
+public class WebSocketEventListener {
+    
+    private static final Logger log = LoggerFactory.getLogger(WebSocketEventListener.class);
+    
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+    
+    // Session ID to Lobby ID mapping to track which lobby a user is in
+    private final Map<String, Long> sessionLobbyMap = new ConcurrentHashMap<>();
+    
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectedEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+        String username = headerAccessor.getUser().getName();
+        
+        log.info("User connected: Session ID {} - User ID {}", sessionId, username);
+    }
+    
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+        String username = headerAccessor.getUser() != null ? headerAccessor.getUser().getName() : "Unknown";
+        
+        log.info("User disconnected: Session ID {} - User ID {}", sessionId, username);
+        
+        // Check if user was in a lobby
+        Long lobbyId = sessionLobbyMap.remove(sessionId);
+        if (lobbyId != null && headerAccessor.getUser() != null) {
+            // Notify others in the lobby that user has disconnected
+            messagingTemplate.convertAndSend(
+                "/topic/lobby/" + lobbyId + "/users",
+                new WebSocketMessage<>("USER_DISCONNECTED", Long.parseLong(username))
+            );
+            
+            log.info("User {} disconnected from lobby {}", username, lobbyId);
+        }
+    }
+    
+    /**
+     * Register a session with a lobby for tracking purposes
+     */
+    public void registerSessionWithLobby(String sessionId, Long lobbyId) {
+        sessionLobbyMap.put(sessionId, lobbyId);
+    }
+    
+    /**
+     * Remove a session from a lobby tracking
+     */
+    public void unregisterSessionFromLobby(String sessionId) {
+        sessionLobbyMap.remove(sessionId);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/controller/LobbyManagerWebSocketController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/controller/LobbyManagerWebSocketController.java
@@ -1,0 +1,581 @@
+package ch.uzh.ifi.hase.soprafs24.websocket.controller;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SubscribeMapping;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.server.ResponseStatusException;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyJoinResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
+import ch.uzh.ifi.hase.soprafs24.service.UserService;
+import ch.uzh.ifi.hase.soprafs24.websocket.WebSocketEventListener;
+import ch.uzh.ifi.hase.soprafs24.websocket.dto.LobbyManagementDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.dto.WebSocketMessage;
+
+@Controller
+public class LobbyManagerWebSocketController {
+    
+    private static final Logger log = LoggerFactory.getLogger(LobbyManagerWebSocketController.class);
+    
+    @Autowired
+    private LobbyService lobbyService;
+    
+    @Autowired
+    private UserService userService;
+    
+    @Autowired
+    private DTOMapper mapper;
+    
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+    
+    @Autowired
+    private WebSocketEventListener webSocketEventListener;
+    
+    /**
+     * Helper method to validate that the user is authenticated
+     */
+    private Long validateAuthentication(Principal principal) {
+        if (principal == null) {
+            log.error("Unauthorized WebSocket request - missing principal");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated");
+        }
+        
+        try {
+            return Long.parseLong(principal.getName());
+        } catch (NumberFormatException e) {
+            log.error("Invalid principal format: {}", principal.getName());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid authentication");
+        }
+    }
+
+    /**
+     * Get all available lobbies when a client subscribes
+     */
+    @SubscribeMapping("/lobby-manager/lobbies")
+    public WebSocketMessage<List<LobbyResponseDTO>> getAllLobbies(Principal principal) {
+        // Add validation for authentication even on subscription methods
+        validateAuthentication(principal);
+        
+        try {
+            List<Lobby> lobbies = lobbyService.listLobbies();
+            List<LobbyResponseDTO> lobbyDTOs = lobbies.stream()
+                .map(mapper::lobbyEntityToResponseDTO)
+                .collect(Collectors.toList());
+            
+            return new WebSocketMessage<>("LOBBIES_LIST", lobbyDTOs);
+        } catch (Exception e) {
+            log.error("Error retrieving lobbies: {}", e.getMessage());
+            return new WebSocketMessage<>("LOBBIES_ERROR", List.of());
+        }
+    }
+
+    /**
+     * Handle join lobby requests via WebSocket
+     */
+    @MessageMapping("/lobby-manager/join/{code}")
+    public void joinLobbyByCode(@DestinationVariable String code,
+                              @Payload WebSocketMessage<Void> message,
+                              Principal principal) {
+        
+        Long userId = validateAuthentication(principal);
+        
+        try {
+            log.info("User {} attempting to join lobby with code {}", userId, code);
+            
+            // Find the lobby by code
+            Lobby lobby = lobbyService.getLobbyByCode(code);
+            if (lobby == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Lobby not found");
+            }
+            
+            // Join the lobby
+            LobbyJoinResponseDTO response = lobbyService.joinLobby(
+                lobby.getId(), userId, null, code, false);
+            
+            // Send confirmation to the user
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/join/result",
+                new WebSocketMessage<>("JOIN_SUCCESS", response)
+            );
+            
+            // Register this user's session with the lobby
+            String sessionId = StompHeaderAccessor.create().getSessionId();
+            if (sessionId != null) {
+                webSocketEventListener.registerSessionWithLobby(sessionId, lobby.getId());
+            }
+            
+        } catch (ResponseStatusException e) {
+            log.error("Error joining lobby: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/join/result",
+                new WebSocketMessage<>(
+                    "JOIN_ERROR", 
+                    Map.of("code", e.getStatus().value(), "message", e.getReason())
+                )
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error joining lobby: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/join/result",
+                new WebSocketMessage<>("JOIN_ERROR", 
+                    Map.of("code", 500, "message", "An unexpected error occurred"))
+            );
+        }
+    }
+
+    /**
+     * Get user's current lobby management state
+     */
+    @SubscribeMapping("/lobby-manager/state")
+    public WebSocketMessage<LobbyManagementDTO> getLobbyManagementState(Principal principal) {
+        Long userId = validateAuthentication(principal);
+        
+        try {
+            // Create the DTO for the response
+            LobbyManagementDTO state = new LobbyManagementDTO();
+            
+            // Get the user's current lobby code if they're in one
+            Lobby currentLobby = lobbyService.getCurrentLobbyForUser(userId);
+            if (currentLobby != null) {
+                state.setCurrentLobbyCode(currentLobby.getLobbyCode());
+            }
+            
+            // Get pending invites if there are any
+            List<LobbyManagementDTO.PendingInvite> pendingInvites = 
+                lobbyService.getPendingInvitesForUser(userId).stream()
+                .map(invite -> {
+                    LobbyManagementDTO.PendingInvite pendingInvite = new LobbyManagementDTO.PendingInvite();
+                    pendingInvite.setUsername(invite.getSender().getProfile().getUsername());
+                    pendingInvite.setLobbyCode(invite.getLobbyCode());
+                    return pendingInvite;
+                })
+                .collect(Collectors.toList());
+            
+            state.setPendingInvites(pendingInvites);
+            
+            return new WebSocketMessage<>("LOBBY_MANAGEMENT_STATE", state);
+        } catch (Exception e) {
+            log.error("Error getting lobby management state: {}", e.getMessage());
+            return new WebSocketMessage<>("LOBBY_MANAGEMENT_ERROR", null);
+        }
+    }
+
+    /**
+     * Get detailed status of a specific lobby
+     */
+    @SubscribeMapping("/lobby-manager/lobby/{lobbyId}")
+    public WebSocketMessage<?> getLobbyStatus(
+            @DestinationVariable Long lobbyId,
+            Principal principal,
+            StompHeaderAccessor headerAccessor) {
+        
+        try {
+            // Validate authentication and get user ID
+            Long userId = validateAuthentication(principal);
+            log.info("User {} requesting status for lobby {}", userId, lobbyId);
+            
+            // Additional check for session information
+            String sessionId = headerAccessor.getSessionId();
+            if (sessionId == null) {
+                log.error("Invalid session for lobby status request");
+                return new WebSocketMessage<>("LOBBY_STATUS_ERROR", Map.of(
+                    "code", HttpStatus.UNAUTHORIZED.value(),
+                    "message", "Invalid session"
+                ));
+            }
+            
+            // Get lobby details
+            Lobby lobby = lobbyService.getLobbyById(lobbyId);
+            
+            // Additional security: Check if user is permitted to view this lobby
+            // For public lobbies or if user is a member/host, this would be allowed
+            if (!lobbyService.isUserInLobby(userId, lobbyId) && lobby.isPrivate()) {
+                log.warn("User {} attempted to access private lobby {} they're not a member of", userId, lobbyId);
+                return new WebSocketMessage<>("LOBBY_STATUS_ERROR", Map.of(
+                    "code", HttpStatus.FORBIDDEN.value(),
+                    "message", "You don't have permission to view this lobby"
+                ));
+            }
+            
+            // Convert to DTO with all status information
+            LobbyResponseDTO lobbyDTO = mapper.lobbyEntityToResponseDTO(lobby);
+            
+            return new WebSocketMessage<>("LOBBY_STATUS", lobbyDTO);
+        } catch (ResponseStatusException e) {
+            log.error("Error retrieving lobby status: {} - {}", e.getStatus(), e.getMessage());
+            return new WebSocketMessage<>("LOBBY_STATUS_ERROR", Map.of(
+                "code", e.getStatus().value(),
+                "message", e.getReason()
+            ));
+        } catch (Exception e) {
+            log.error("Unexpected error retrieving lobby status: {}", e.getMessage());
+            return new WebSocketMessage<>("LOBBY_STATUS_ERROR", Map.of(
+                "code", HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "message", "An unexpected error occurred"
+            ));
+        }
+    }
+
+    /**
+     * Send a lobby invite
+     */
+    @MessageMapping("/lobby-manager/invite")
+    public void sendLobbyInvite(@Payload WebSocketMessage<Map<String, String>> message,
+                                Principal principal) {
+        Long senderId = validateAuthentication(principal);
+        Map<String, String> payload = message.getPayload();
+        String toUsername = payload.get("toUsername");
+        
+        try {
+            log.info("User {} sending lobby invite to {}", senderId, toUsername);
+            
+            // Get the sender user
+            User sender = userService.getPublicProfile(senderId);
+            
+            // Find recipient by username
+            User recipient = userService.findByUsername(toUsername);
+            if (recipient == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+            }
+            
+            // Get current lobby code for the sender
+            Lobby currentLobby = lobbyService.getCurrentLobbyForUser(senderId);
+            if (currentLobby == null) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "You must be in a lobby to invite others");
+            }
+            
+            String lobbyCode = currentLobby.getLobbyCode();
+            
+            // Create and store the invite in the service
+            lobbyService.createLobbyInvite(sender, recipient, lobbyCode);
+            
+            // Send confirmation to the sender
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/result",
+                new WebSocketMessage<>("INVITE_SENT", Map.of(
+                    "recipient", toUsername,
+                    "lobbyCode", lobbyCode
+                ))
+            );
+            
+            // Send notification to the recipient
+            messagingTemplate.convertAndSendToUser(
+                recipient.getId().toString(),
+                "/topic/lobby-manager/invites",
+                new WebSocketMessage<>("INVITE_IN", Map.of(
+                    "fromUsername", sender.getProfile().getUsername(),
+                    "lobbyCode", lobbyCode
+                ))
+            );
+            
+        } catch (ResponseStatusException e) {
+            log.error("Error sending invite: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/result",
+                new WebSocketMessage<>("INVITE_ERROR", Map.of(
+                    "code", e.getStatus().value(),
+                    "message", e.getReason()
+                ))
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error sending invite: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/result",
+                new WebSocketMessage<>("INVITE_ERROR", Map.of(
+                    "code", 500,
+                    "message", "An unexpected error occurred"
+                ))
+            );
+        }
+    }
+
+    /**
+     * Cancel a pending lobby invite
+     */
+    @MessageMapping("/lobby-manager/invite/cancel")
+    public void cancelLobbyInvite(@Payload WebSocketMessage<Map<String, String>> message,
+                                  Principal principal) {
+        Long senderId = validateAuthentication(principal);
+        Map<String, String> payload = message.getPayload();
+        String toUsername = payload.get("toUsername");
+        
+        try {
+            log.info("User {} canceling lobby invite to {}", senderId, toUsername);
+            
+            // Get the sender and recipient
+            User sender = userService.getPublicProfile(senderId);
+            User recipient = userService.findByUsername(toUsername);
+            
+            if (recipient == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+            }
+            
+            // Cancel the invite
+            boolean canceled = lobbyService.cancelLobbyInvite(sender, recipient);
+            
+            if (!canceled) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No pending invite found");
+            }
+            
+            // Send confirmation to the sender
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/cancel/result",
+                new WebSocketMessage<>("INVITE_CANCELED", Map.of("recipient", toUsername))
+            );
+            
+            // Notify the recipient that the invite was canceled
+            messagingTemplate.convertAndSendToUser(
+                recipient.getId().toString(),
+                "/topic/lobby-manager/invites",
+                new WebSocketMessage<>("INVITE_CANCELED", Map.of(
+                    "fromUsername", sender.getProfile().getUsername()
+                ))
+            );
+            
+        } catch (ResponseStatusException e) {
+            log.error("Error canceling invite: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/cancel/result",
+                new WebSocketMessage<>("INVITE_CANCEL_ERROR", Map.of(
+                    "code", e.getStatus().value(),
+                    "message", e.getReason()
+                ))
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error canceling invite: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/cancel/result",
+                new WebSocketMessage<>("INVITE_CANCEL_ERROR", Map.of(
+                    "code", 500,
+                    "message", "An unexpected error occurred"
+                ))
+            );
+        }
+    }
+
+    /**
+     * Accept a friend invite to join their lobby
+     * This endpoint specifically handles friend invites and doesn't expect a lobby code from clients
+     */
+    @MessageMapping("/lobby-manager/invite/accept")
+    public void acceptFriendLobbyInvite(@Payload WebSocketMessage<Map<String, String>> message,
+                             Principal principal,
+                             StompHeaderAccessor headerAccessor) {
+        Long recipientId = validateAuthentication(principal);
+        Map<String, String> payload = message.getPayload();
+        String fromUsername = payload.get("fromUsername");
+        
+        try {
+            log.info("User {} accepting friend invite from {}", recipientId, fromUsername);
+            
+            // Additional check for session information
+            String sessionId = headerAccessor.getSessionId();
+            if (sessionId == null) {
+                log.error("Invalid session for friend invite accept request");
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby-manager/invite/accept/result",
+                    new WebSocketMessage<>("INVITE_ACCEPT_ERROR", Map.of(
+                        "code", HttpStatus.UNAUTHORIZED.value(),
+                        "message", "Invalid session"
+                    ))
+                );
+                return;
+            }
+            
+            // Find the sender by username
+            User sender = userService.findByUsername(fromUsername);
+            if (sender == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Inviting user not found");
+            }
+            
+            // Get the recipient
+            User recipient = userService.getPublicProfile(recipientId);
+            
+            // For friend invites, we always look up the sender's current lobby
+            log.info("Looking up current lobby of friend: {}", fromUsername);
+            Lobby senderLobby = lobbyService.getCurrentLobbyForUser(sender.getId());
+            if (senderLobby == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, 
+                    "Your friend is not currently in any lobby");
+            }
+            String lobbyCode = senderLobby.getLobbyCode();
+            log.info("Found friend's lobby with code: {}", lobbyCode);
+            
+            // Verify that an invite exists from this sender
+            if (!lobbyService.hasAnyPendingInviteFrom(sender, recipient)) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No invite found from this friend");
+            }
+            
+            // Join the friend's lobby
+            LobbyJoinResponseDTO response = lobbyService.joinLobby(
+                senderLobby.getId(), recipientId, null, lobbyCode, true);
+            
+            // Register this user's session with the lobby
+            webSocketEventListener.registerSessionWithLobby(sessionId, senderLobby.getId());
+            
+            // Remove the invite as it's been accepted
+            lobbyService.cancelLobbyInvite(sender, recipient);
+            
+            // Send confirmation to the recipient
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/accept/result",
+                new WebSocketMessage<>("INVITE_ACCEPTED", response)
+            );
+            
+            // Notify the original sender that their invite was accepted
+            messagingTemplate.convertAndSendToUser(
+                sender.getId().toString(),
+                "/topic/lobby-manager/invites/status",
+                new WebSocketMessage<>("INVITE_ACCEPTED", Map.of(
+                    "username", recipient.getProfile().getUsername(),
+                    "lobbyCode", lobbyCode
+                ))
+            );
+            
+            // Broadcast to the lobby that a new user has joined
+            messagingTemplate.convertAndSend(
+                "/topic/lobby/" + senderLobby.getId() + "/users",
+                new WebSocketMessage<>("USER_JOINED", mapper.toUserPublicDTO(recipient))
+            );
+            
+        } catch (ResponseStatusException e) {
+            log.error("Error accepting friend invite: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/accept/result",
+                new WebSocketMessage<>("INVITE_ACCEPT_ERROR", Map.of(
+                    "code", e.getStatus().value(),
+                    "message", e.getReason()
+                ))
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error accepting friend invite: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/accept/result",
+                new WebSocketMessage<>("INVITE_ACCEPT_ERROR", Map.of(
+                    "code", HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "message", "An unexpected error occurred"
+                ))
+            );
+        }
+    }
+
+    /**
+     * Decline a friend's lobby invite
+     */
+    @MessageMapping("/lobby-manager/invite/decline")
+    public void declineFriendLobbyInvite(@Payload WebSocketMessage<Map<String, String>> message,
+                                    Principal principal,
+                                    StompHeaderAccessor headerAccessor) {
+        Long recipientId = validateAuthentication(principal);
+        Map<String, String> payload = message.getPayload();
+        String fromUsername = payload.get("fromUsername");
+        
+        try {
+            log.info("User {} declining invite from {}", recipientId, fromUsername);
+            
+            // Additional check for session information
+            String sessionId = headerAccessor.getSessionId();
+            if (sessionId == null) {
+                log.error("Invalid session for invite decline request");
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby-manager/invite/decline/result",
+                    new WebSocketMessage<>("INVITE_DECLINE_ERROR", Map.of(
+                        "code", HttpStatus.UNAUTHORIZED.value(),
+                        "message", "Invalid session"
+                    ))
+                );
+                return;
+            }
+            
+            // Find the sender by username
+            User sender = userService.findByUsername(fromUsername);
+            if (sender == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Inviting user not found");
+            }
+            
+            // Get the recipient (current user)
+            User recipient = userService.getPublicProfile(recipientId);
+            
+            // Verify that an invite exists from this sender
+            if (!lobbyService.hasAnyPendingInviteFrom(sender, recipient)) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No invite found from this friend");
+            }
+            
+            // Remove the invite as it's been declined
+            lobbyService.cancelLobbyInvite(sender, recipient);
+            
+            // Send confirmation to the recipient that the decline was processed
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/decline/result",
+                new WebSocketMessage<>("INVITE_DECLINED", Map.of(
+                    "fromUsername", fromUsername,
+                    "message", "Invite declined successfully"
+                ))
+            );
+            
+            // Notify the original sender that their invite was declined
+            messagingTemplate.convertAndSendToUser(
+                sender.getId().toString(),
+                "/topic/lobby-manager/invites/status",
+                new WebSocketMessage<>("INVITE_DECLINED", Map.of(
+                    "username", recipient.getProfile().getUsername(),
+                    "message", "Your invite was declined"
+                ))
+            );
+            
+        } catch (ResponseStatusException e) {
+            log.error("Error declining invite: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/decline/result",
+                new WebSocketMessage<>("INVITE_DECLINE_ERROR", Map.of(
+                    "code", e.getStatus().value(),
+                    "message", e.getReason()
+                ))
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error declining invite: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/invite/decline/result",
+                new WebSocketMessage<>("INVITE_DECLINE_ERROR", Map.of(
+                    "code", HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    "message", "An unexpected error occurred"
+                ))
+            );
+        }
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/controller/LobbyWebSocketController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/controller/LobbyWebSocketController.java
@@ -1,0 +1,470 @@
+package ch.uzh.ifi.hase.soprafs24.websocket.controller;
+
+import java.security.Principal;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.server.ResponseStatusException;
+
+import ch.uzh.ifi.hase.soprafs24.entity.Lobby;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.GenericMessageResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyConfigUpdateRequestDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyJoinResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyLeaveResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyRequestDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
+import ch.uzh.ifi.hase.soprafs24.service.UserService;
+import ch.uzh.ifi.hase.soprafs24.websocket.WebSocketEventListener;
+import ch.uzh.ifi.hase.soprafs24.websocket.dto.LobbyDTO;
+import ch.uzh.ifi.hase.soprafs24.websocket.dto.WebSocketMessage;
+
+/**
+ * Controller for in-lobby interactions
+ */
+@Controller
+public class LobbyWebSocketController {
+    
+    private static final Logger log = LoggerFactory.getLogger(LobbyWebSocketController.class);
+    
+    @Autowired
+    private LobbyService lobbyService;
+    
+    @Autowired
+    private UserService userService;
+    
+    @Autowired
+    private DTOMapper mapper;
+    
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+    
+    @Autowired
+    private WebSocketEventListener webSocketEventListener;
+
+    /**
+     * Helper method to validate that the user is authenticated
+     */
+    private Long validateAuthentication(Principal principal) {
+        if (principal == null) {
+            log.error("Unauthorized WebSocket request - missing principal");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated");
+        }
+        
+        try {
+            return Long.parseLong(principal.getName());
+        } catch (NumberFormatException e) {
+            log.error("Invalid principal format: {}", principal.getName());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid authentication");
+        }
+    }
+
+    /**
+     * Create a new lobby
+     */
+    @MessageMapping("/lobby/create")
+    public void createLobby(@Payload WebSocketMessage<LobbyRequestDTO> message, 
+                           Principal principal,
+                           StompHeaderAccessor headerAccessor) {
+        Long userId = validateAuthentication(principal);
+        
+        try {
+            // Verify session validity
+            String sessionId = headerAccessor.getSessionId();
+            if (sessionId == null) {
+                log.error("Invalid session for lobby creation request");
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby/create/result",
+                    new WebSocketMessage<>("LOBBY_CREATE_ERROR", "Invalid session")
+                );
+                return;
+            }
+            
+            log.info("User {} creating new lobby", userId);
+            
+            // Convert DTO to entity
+            Lobby lobbyEntity = mapper.lobbyRequestDTOToEntity(message.getPayload());
+            lobbyEntity.setHost(userService.getPublicProfile(userId));
+            
+            // Create the lobby
+            Lobby createdLobby = lobbyService.createLobby(lobbyEntity);
+            
+            // Convert to required Lobby format for WebSocket response
+            LobbyDTO lobbyDTO = new LobbyDTO();
+            lobbyDTO.setCode(createdLobby.getLobbyCode());
+            lobbyDTO.setMaxPlayers(String.valueOf(createdLobby.getMaxPlayers()));
+            lobbyDTO.setPlayersPerTeam(createdLobby.getMaxPlayersPerTeam());
+            if (createdLobby.getHintsEnabled() != null) {
+                lobbyDTO.setRoundCardsStartAmount(createdLobby.getHintsEnabled().size());
+            }
+            
+            // Register this user's session with the newly created lobby
+            webSocketEventListener.registerSessionWithLobby(sessionId, createdLobby.getId());
+            
+            // Send confirmation to the creator
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby/create/result",
+                new WebSocketMessage<>("LOBBY_CREATED", lobbyDTO)
+            );
+            
+            // Broadcast to all subscribers that a new lobby was created
+            messagingTemplate.convertAndSend(
+                "/topic/lobbies",
+                new WebSocketMessage<>("LOBBY_ADDED", lobbyDTO)
+            );
+            
+        } catch (Exception e) {
+            log.error("Error creating lobby: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby/create/result",
+                new WebSocketMessage<>("LOBBY_CREATE_ERROR", e.getMessage())
+            );
+        }
+    }
+    
+    /**
+     * Handle lobby update settings
+     * Type "UPDATE"
+     */
+    @MessageMapping("/lobby/{lobbyId}/update")
+    public void updateLobbySettings(@DestinationVariable Long lobbyId, 
+                                  @Payload WebSocketMessage<LobbyDTO> message,
+                                  Principal principal,
+                                  StompHeaderAccessor headerAccessor) {
+        Long userId = validateAuthentication(principal);
+        log.info("User {} attempting to update lobby {}", userId, lobbyId);
+        
+        try {
+            // Validate session
+            String sessionId = headerAccessor.getSessionId();
+            if (sessionId == null) {
+                log.error("Invalid session for lobby update request");
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby/update/error",
+                    new WebSocketMessage<>("UPDATE_ERROR", "Invalid session")
+                );
+                return;
+            }
+            
+            // Convert from LobbyDTO to UpdateRequest
+            LobbyConfigUpdateRequestDTO updateRequest = new LobbyConfigUpdateRequestDTO();
+            LobbyDTO lobbyData = message.getPayload();
+            
+            // Set the appropriate fields
+            if (lobbyData.getMaxPlayers() != null) {
+                try {
+                    updateRequest.setMaxPlayers(Integer.parseInt(lobbyData.getMaxPlayers()));
+                } catch (NumberFormatException e) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid maxPlayers format");
+                }
+            }
+            
+            if (lobbyData.getPlayersPerTeam() != null) {
+                updateRequest.setMaxPlayersPerTeam(lobbyData.getPlayersPerTeam());
+            }
+            
+            // Update the lobby
+            Lobby updatedLobby = lobbyService.updateLobbyConfig(lobbyId, updateRequest, userId);
+            LobbyResponseDTO responseDTO = mapper.lobbyEntityToResponseDTO(updatedLobby);
+            
+            // Convert to the required Lobby format
+            LobbyDTO responseLobbyDTO = convertToLobbyDTO(responseDTO);
+            
+            // Send success message to everyone in the lobby
+            messagingTemplate.convertAndSend(
+                "/topic/lobby/" + lobbyId, 
+                new WebSocketMessage<>("UPDATE_SUCCESS", responseLobbyDTO)
+            );
+            
+        } catch (ResponseStatusException e) {
+            // Handle specific error cases
+            if (e.getStatus() == HttpStatus.FORBIDDEN) {
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby/update/error",
+                    new WebSocketMessage<>("UPDATE_ERROR", "Only the host can update lobby configuration")
+                );
+            } else if (e.getStatus() == HttpStatus.BAD_REQUEST) {
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby/update/error",
+                    new WebSocketMessage<>("UPDATE_ERROR", "Invalid parameters submitted.")
+                );
+            } else {
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby/update/error",
+                    new WebSocketMessage<>("UPDATE_ERROR", e.getMessage())
+                );
+            }
+        } catch (Exception e) {
+            log.error("Error updating lobby: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby/update/error",
+                new WebSocketMessage<>("UPDATE_ERROR", "An unexpected error occurred")
+            );
+        }
+    }
+    
+    /**
+     * Handle leave lobby
+     * Type "LEAVE"
+     */
+    @MessageMapping("/lobby/{lobbyId}/leave")
+    public void leaveLobby(@DestinationVariable Long lobbyId,
+                          @Payload WebSocketMessage<Map<String, String>> message,
+                          Principal principal,
+                          StompHeaderAccessor headerAccessor) {
+        Long userId = validateAuthentication(principal);
+        log.info("User {} leaving lobby {}", userId, lobbyId);
+        
+        try {
+            // Get the session ID and unregister it
+            String sessionId = headerAccessor.getSessionId();
+            if (sessionId != null) {
+                webSocketEventListener.unregisterSessionFromLobby(sessionId);
+            }
+            
+            // Check if user is the host before processing leave
+            boolean isHost = lobbyService.isUserHost(lobbyId, userId);
+            
+            if (isHost) {
+                // If the host is leaving, delete the lobby instead of just removing the user
+                GenericMessageResponseDTO response = lobbyService.deleteLobby(lobbyId, userId);
+                
+                // Send confirmation to the host that they've left
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(), 
+                    "/topic/lobby/leave/result", 
+                    new WebSocketMessage<>("LEAVE_SUCCESS", null)
+                );
+                
+                // Notify all users in the lobby that it was disbanded
+                messagingTemplate.convertAndSend(
+                    "/topic/lobby/" + lobbyId,
+                    new WebSocketMessage<>("LOBBY_DISBANDED", 
+                        Map.of("message", "Lobby disbanded because host left"))
+                );
+                
+                // Broadcast to all subscribers that a lobby was deleted
+                messagingTemplate.convertAndSend(
+                    "/topic/lobby-manager/lobbies",
+                    new WebSocketMessage<>("LOBBY_REMOVED", lobbyId)
+                );
+            } else {
+                // Regular user leaving, process normal leave
+                LobbyLeaveResponseDTO response = lobbyService.leaveLobby(lobbyId, userId, userId);
+                
+                // Send confirmation to the user
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(), 
+                    "/topic/lobby/leave/result", 
+                    new WebSocketMessage<>("LEAVE_SUCCESS", convertToLobbyDTO(response.getLobby()))
+                );
+                
+                // Broadcast to all users in the lobby that a user has left
+                messagingTemplate.convertAndSend(
+                    "/topic/lobby/" + lobbyId + "/users", 
+                    new WebSocketMessage<>("USER_LEFT", Map.of("userId", userId))
+                );
+            }
+            
+        } catch (ResponseStatusException e) {
+            if (e.getStatus() == HttpStatus.FORBIDDEN) {
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(), 
+                    "/topic/lobby/leave/result", 
+                    new WebSocketMessage<>("LEAVE_ERROR", "Only the host can kick players")
+                );
+            } else if (e.getStatus() == HttpStatus.BAD_REQUEST) {
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(), 
+                    "/topic/lobby/leave/result", 
+                    new WebSocketMessage<>("LEAVE_ERROR", "User not in lobby")
+                );
+            } else {
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(), 
+                    "/topic/lobby/leave/result", 
+                    new WebSocketMessage<>("LEAVE_ERROR", e.getMessage())
+                );
+            }
+        } catch (Exception e) {
+            log.error("Error leaving lobby: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(), 
+                "/topic/lobby/leave/result", 
+                new WebSocketMessage<>("LEAVE_ERROR", e.getMessage())
+            );
+        }
+    }
+    
+    /**
+     * Delete a lobby (moved from LobbyManagerWebSocketController)
+     */
+    @MessageMapping("/lobby-manager/delete/{lobbyId}")
+    public void deleteLobby(@DestinationVariable Long lobbyId, 
+                           Principal principal, 
+                           StompHeaderAccessor headerAccessor) {
+        Long userId = validateAuthentication(principal);
+        
+        try {
+            log.info("User {} attempting to delete lobby {}", userId, lobbyId);
+            
+            // Verify session
+            String sessionId = headerAccessor.getSessionId();
+            if (sessionId == null) {
+                log.error("Invalid session for lobby deletion request");
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby-manager/delete/result",
+                    new WebSocketMessage<>("LOBBY_DELETE_ERROR", "Invalid session")
+                );
+                return;
+            }
+            
+            // Delete the lobby
+            GenericMessageResponseDTO response = lobbyService.deleteLobby(lobbyId, userId);
+            
+            // Send confirmation to the user
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/delete/result",
+                new WebSocketMessage<>("LOBBY_DELETED", response)
+            );
+            
+            // Broadcast to all subscribers that a lobby was deleted
+            messagingTemplate.convertAndSend(
+                "/topic/lobby-manager/lobbies",
+                new WebSocketMessage<>("LOBBY_REMOVED", lobbyId)
+            );
+            
+            // Notify all users in the lobby that it was disbanded
+            messagingTemplate.convertAndSend(
+                "/topic/lobby/" + lobbyId,
+                new WebSocketMessage<>("LOBBY_DISBANDED", response)
+            );
+            
+        } catch (Exception e) {
+            log.error("Error deleting lobby: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby-manager/delete/result",
+                new WebSocketMessage<>("LOBBY_DELETE_ERROR", e.getMessage())
+            );
+        }
+    }
+    
+    /**
+     * Join lobby by code
+     */
+    @MessageMapping("/lobby/join/{code}")
+    public void joinLobbyByCode(@DestinationVariable String code,
+                              @Payload WebSocketMessage<Void> message,
+                              Principal principal,
+                              StompHeaderAccessor headerAccessor) {
+        Long userId = validateAuthentication(principal);
+        
+        try {
+            log.info("User {} attempting to join lobby with code {}", userId, code);
+            
+            // Check for session ID
+            String sessionId = headerAccessor.getSessionId();
+            if (sessionId == null) {
+                log.error("Invalid session for join request");
+                messagingTemplate.convertAndSendToUser(
+                    principal.getName(),
+                    "/topic/lobby/join/result",
+                    new WebSocketMessage<>("JOIN_ERROR", "Invalid session")
+                );
+                return;
+            }
+            
+            // Find the lobby by code
+            Lobby lobby = lobbyService.getLobbyByCode(code);
+            if (lobby == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Lobby not found");
+            }
+            
+            // Join the lobby
+            LobbyJoinResponseDTO response = lobbyService.joinLobby(
+                lobby.getId(), userId, null, code, false);
+            
+            // Register this user's session with the lobby
+            webSocketEventListener.registerSessionWithLobby(sessionId, lobby.getId());
+            
+            // Send confirmation to the user
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby/join/result",
+                new WebSocketMessage<>("JOIN_SUCCESS", convertToLobbyDTO(response.getLobby()))
+            );
+            
+            // Broadcast to the lobby that a new user has joined
+            User user = userService.getPublicProfile(userId);
+            messagingTemplate.convertAndSend(
+                "/topic/lobby/" + lobby.getId() + "/users",
+                new WebSocketMessage<>("USER_JOINED", mapper.toUserPublicDTO(user))
+            );
+            
+        } catch (ResponseStatusException e) {
+            String errorMessage;
+            if (e.getStatus() == HttpStatus.NOT_FOUND) {
+                errorMessage = "Lobby not found";
+            } else if (e.getStatus() == HttpStatus.BAD_REQUEST) {
+                errorMessage = "Lobby is full";
+            } else if (e.getStatus() == HttpStatus.FORBIDDEN) {
+                errorMessage = "You need to be logged in to join a lobby.";
+            } else {
+                errorMessage = e.getMessage();
+            }
+            
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby/join/result",
+                new WebSocketMessage<>("JOIN_ERROR", errorMessage)
+            );
+        } catch (Exception e) {
+            log.error("Unexpected error joining lobby: {}", e.getMessage());
+            messagingTemplate.convertAndSendToUser(
+                principal.getName(),
+                "/topic/lobby/join/result",
+                new WebSocketMessage<>("JOIN_ERROR", "An unexpected error occurred")
+            );
+        }
+    }
+    
+    /**
+     * Helper method to convert LobbyResponseDTO to LobbyDTO for WebSocket responses
+     */
+    private LobbyDTO convertToLobbyDTO(LobbyResponseDTO responseDTO) {
+        if (responseDTO == null) {
+            return null;
+        }
+        
+        LobbyDTO dto = new LobbyDTO();
+        dto.setCode(responseDTO.getCode());
+        dto.setMaxPlayers(responseDTO.getMaxPlayers());
+        dto.setPlayersPerTeam(responseDTO.getPlayersPerTeam());
+        dto.setRoundCardsStartAmount(responseDTO.getRoundCardsStartAmount());
+        
+        return dto;
+    }
+}
+

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/LobbyDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/LobbyDTO.java
@@ -1,0 +1,44 @@
+package ch.uzh.ifi.hase.soprafs24.websocket.dto;
+
+/**
+ * Data transfer object for Lobby in WebSocket messages
+ */
+public class LobbyDTO {
+    private String code;
+    private String maxPlayers;
+    private Integer playersPerTeam;
+    private Integer roundCardsStartAmount;
+    
+    // Getters and setters
+    public String getCode() {
+        return code;
+    }
+    
+    public void setCode(String code) {
+        this.code = code;
+    }
+    
+    public String getMaxPlayers() {
+        return maxPlayers;
+    }
+    
+    public void setMaxPlayers(String maxPlayers) {
+        this.maxPlayers = maxPlayers;
+    }
+    
+    public Integer getPlayersPerTeam() {
+        return playersPerTeam;
+    }
+    
+    public void setPlayersPerTeam(Integer playersPerTeam) {
+        this.playersPerTeam = playersPerTeam;
+    }
+    
+    public Integer getRoundCardsStartAmount() {
+        return roundCardsStartAmount;
+    }
+    
+    public void setRoundCardsStartAmount(Integer roundCardsStartAmount) {
+        this.roundCardsStartAmount = roundCardsStartAmount;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/LobbyManagementDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/LobbyManagementDTO.java
@@ -1,0 +1,53 @@
+package ch.uzh.ifi.hase.soprafs24.websocket.dto;
+
+import java.util.List;
+
+/**
+ * Data transfer object for lobby management state
+ * Used to send information about a user's current lobby and pending invites
+ */
+public class LobbyManagementDTO {
+    private String currentLobbyCode;
+    private List<PendingInvite> pendingInvites;
+
+    /**
+     * Inner class representing a pending lobby invitation
+     */
+    public static class PendingInvite {
+        private String username;
+        private String lobbyCode;
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getLobbyCode() {
+            return lobbyCode;
+        }
+
+        public void setLobbyCode(String lobbyCode) {
+            this.lobbyCode = lobbyCode;
+        }
+    }
+
+    // Getters and setters
+    public String getCurrentLobbyCode() {
+        return currentLobbyCode;
+    }
+
+    public void setCurrentLobbyCode(String currentLobbyCode) {
+        this.currentLobbyCode = currentLobbyCode;
+    }
+
+    public List<PendingInvite> getPendingInvites() {
+        return pendingInvites;
+    }
+
+    public void setPendingInvites(List<PendingInvite> pendingInvites) {
+        this.pendingInvites = pendingInvites;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/WebSocketMessage.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/WebSocketMessage.java
@@ -1,0 +1,47 @@
+package ch.uzh.ifi.hase.soprafs24.websocket.dto;
+
+import java.time.Instant;
+
+public class WebSocketMessage<T> {
+    
+    private String type;
+    private T payload;
+    private Instant timestamp;
+    
+    // Default constructor for JSON deserialization
+    public WebSocketMessage() {
+        this.timestamp = Instant.now();
+    }
+    
+    // Constructor with type and payload
+    public WebSocketMessage(String type, T payload) {
+        this.type = type;
+        this.payload = payload;
+        this.timestamp = Instant.now();
+    }
+    
+    // Getters and setters
+    public String getType() {
+        return type;
+    }
+    
+    public void setType(String type) {
+        this.type = type;
+    }
+    
+    public T getPayload() {
+        return payload;
+    }
+    
+    public void setPayload(T payload) {
+        this.payload = payload;
+    }
+    
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+    
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerTest.java
@@ -130,8 +130,8 @@ public class LobbyControllerTest {
         casualResponseDTO.setMode("solo");
         casualResponseDTO.setPrivate(true);
         casualResponseDTO.setLobbyCode("12345");
-        casualResponseDTO.setMaxPlayers(8); // For solo mode, this is set
-        // maxPlayersPerTeam should not appear in the response for solo mode
+        casualResponseDTO.setMaxPlayers("8"); // Changed to String
+        casualResponseDTO.setRoundCardsStartAmount(5); // New field
         
         when(authService.getUserByToken(token)).thenReturn(dummyUser);
         when(mapper.lobbyRequestDTOToEntity(any(LobbyRequestDTO.class))).thenReturn(casualLobby);
@@ -148,9 +148,10 @@ public class LobbyControllerTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.lobbyId").value(casualResponseDTO.getLobbyId()))
         .andExpect(jsonPath("$.mode").value("solo")) // Mode is enforced to solo
-        .andExpect(jsonPath("$.lobbyCode").value("12345")) // Has generated code
-        .andExpect(jsonPath("$.maxPlayers").value(8)) // MaxPlayers is shown
-        .andExpect(jsonPath("$.maxPlayersPerTeam").doesNotExist()); // No maxPlayersPerTeam in solo mode
+        .andExpect(jsonPath("$.code").value("12345")) // Updated field name
+        .andExpect(jsonPath("$.maxPlayers").value("8")) // Changed to String
+        .andExpect(jsonPath("$.roundCardsStartAmount").value(5)) // New field
+        .andExpect(jsonPath("$.playersPerTeam").doesNotExist()); // Updated field name
     }
     
     @Test

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
@@ -4,32 +4,30 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.is;
-
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserDeleteRequestDTO;
 import org.junit.jupiter.api.Test;
-
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.entity.UserProfile;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.UserDeleteRequestDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.UserPublicDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserUpdateRequestDTO;
-import ch.uzh.ifi.hase.soprafs24.rest.dto.UserUpdateResponseDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.UserSearchRequestDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.UserSearchResponseDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.UserUpdateRequestDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.UserUpdateResponseDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs24.service.AuthService;
 import ch.uzh.ifi.hase.soprafs24.service.UserService;
@@ -69,6 +67,7 @@ public class UserControllerTest {
         UserProfile profile = new UserProfile();
         profile.setUsername("firstnameLastname");
         profile.setMmr(1500);
+        profile.setPoints(1500); // Add points to match the DTO
         profile.setAchievements(Arrays.asList("First Win"));
         user.setProfile(profile);
 
@@ -77,21 +76,24 @@ public class UserControllerTest {
         publicDTO.setUserid(1L);
         publicDTO.setUsername(profile.getUsername());
         publicDTO.setMmr(profile.getMmr());
+        publicDTO.setPoints(profile.getPoints()); // Set points to be returned
+        publicDTO.setEmail(user.getEmail());
+        // No need to set achievements as they are @JsonIgnore'd
         publicDTO.setAchievements(profile.getAchievements());
 
         given(userService.getPublicProfile(eq(1L))).willReturn(user);
         given(mapper.toUserPublicDTO(user)).willReturn(publicDTO);
 
         // when/then
-
         mockMvc.perform(get("/users/1")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.userid", is(1)))
             .andExpect(jsonPath("$.username", is(profile.getUsername())))
             .andExpect(jsonPath("$.mmr", is(profile.getMmr())))
-            .andExpect(jsonPath("$.achievements[0]", is("First Win")));
-
+            .andExpect(jsonPath("$.points", is(profile.getPoints())))
+            .andExpect(jsonPath("$.email", is(user.getEmail())));
+            // Remove the assertion for $.achievements since it's @JsonIgnore'd in UserPublicDTO
     }
 
     // Test for PUT /api/users/me

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -120,8 +120,9 @@ public class LobbyServiceIntegrationTest {
         // Check that the DTO correctly maps the solo mode lobby
         LobbyResponseDTO soloDTO = mapper.lobbyEntityToResponseDTO(soloLobby);
         assertEquals("solo", soloDTO.getMode());
-        assertEquals(8, soloDTO.getMaxPlayers()); // Default maxPlayers is 8
-        assertNull(soloDTO.getMaxPlayersPerTeam()); // Should not expose maxPlayersPerTeam
+        assertEquals("8", soloDTO.getMaxPlayers()); // MaxPlayers is now a String
+        assertNull(soloDTO.getPlayersPerTeam()); // Renamed from maxPlayersPerTeam
+        assertEquals(soloLobby.getLobbyCode(), soloDTO.getCode()); // Check new field name
     }
 
     @Test
@@ -142,12 +143,18 @@ public class LobbyServiceIntegrationTest {
         
         // Verify the DTO mapper includes these cards in the response
         LobbyResponseDTO responseDTO = mapper.lobbyEntityToResponseDTO(createdLobby);
+        
+        // Verify both fields are set properly for compatibility
         assertNotNull(responseDTO.getRoundCards());
         assertEquals(createdLobby.getHintsEnabled(), responseDTO.getRoundCards());
         
-        // Verify the expected default card values
-        assertTrue(responseDTO.getRoundCards().contains("STANDARD_CARD_1"));
-        assertTrue(responseDTO.getRoundCards().contains("STANDARD_CARD_5"));
+        // Verify new field is also set correctly
+        assertNotNull(responseDTO.getRoundCardsStartAmount());
+        assertEquals(5, responseDTO.getRoundCardsStartAmount().intValue());
+        
+        // Verify the expected default card values still exist in the entity
+        assertTrue(createdLobby.getHintsEnabled().contains("STANDARD_CARD_1"));
+        assertTrue(createdLobby.getHintsEnabled().contains("STANDARD_CARD_5"));
     }
 
     @Test
@@ -215,6 +222,8 @@ public class LobbyServiceIntegrationTest {
         assertNotNull(response);
         assertNotNull(response.getLobby());
         assertEquals(teamLobby.getId(), response.getLobby().getLobbyId());
+        // Check the code field is present in the response
+        assertEquals(lobbyCode, response.getLobby().getCode());
     }
     
     @Test


### PR DESCRIPTION
### Related Issues

Closes #125, Closes #127, Closes #128, Closes #129, Closes #127, Closes #258

### Changes
- Added the Lobby Web Socket with the following endpoints:

- /app/lobby-manager/lobby/{lobbyId} -> Get lobby status
- /app/lobby-manager/invite -> Send a lobby invite
- /app/lobby-manager/invite/accept-> Accept lobby invite (friend only)
- /app/lobby-manager/invite/decline -> Decline lobby invite (friend only)
- /app/lobby-manager/invite/cancel -> Cancel a pending lobby invite
- /app/lobby/create -> Better to use a regular REST API - works well, tested.
- /app/lobby-manager/join/{code} -> Join lobby (non-friend)
- /app/lobby/{lobbyId}/update -> Update lobby settings
- /app/lobby/{lobbyId}/leave -> Leave lobby
- /app/lobby-manager/delete/{lobbyId} -> Delete lobby