### PR TITLE
Added the XP instead of MMR. Added the logic to calculate the XP and …

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/UserProfile.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/UserProfile.java
@@ -17,9 +17,9 @@ public class UserProfile implements Serializable {
     @Column(nullable = false)
     private String username;
 
-    // "MMR" 
+    // Renamed from "mmr" to "xp"
     @Column(nullable = false)
-    private int mmr;
+    private int xp;
 
     @Column(nullable = false)
     private int points;
@@ -82,11 +82,12 @@ public class UserProfile implements Serializable {
         this.statsPublic = statsPublic;
     }
 
-    public int getMmr() {
-        return mmr;
+    // Renamed from getMmr/setMmr to getXp/setXp
+    public int getXp() {
+        return xp;
     }
-    public void setMmr(int mmr) {
-        this.mmr = mmr;
+    public void setXp(int xp) {
+        this.xp = xp;
     }
 
     public int getPoints() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPublicDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPublicDTO.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class UserPublicDTO {
     private Long userid;
     private String username;
-    private int mmr;
+    private int xp; // Renamed from mmr to xp
     private int points;
     @JsonIgnore
     private List<String> achievements;
@@ -27,11 +27,11 @@ public class UserPublicDTO {
         this.username = username;
     }
 
-    public int getMmr() {
-        return mmr;
+    public int getXp() { // Renamed from getMmr to getXp
+        return xp;
     }
-    public void setMmr(int mmr) {
-        this.mmr = mmr;
+    public void setXp(int xp) { // Renamed from setMmr to setXp
+        this.xp = xp;
     }
 
     public int getPoints() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserStatsDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserStatsDTO.java
@@ -3,7 +3,7 @@ package ch.uzh.ifi.hase.soprafs24.rest.dto;
 public class UserStatsDTO {
     private int gamesPlayed;
     private int wins;
-    private int mmr;
+    private int xp; // Renamed from mmr to xp
     private int points;
 
     public int getGamesPlayed() {
@@ -22,12 +22,12 @@ public class UserStatsDTO {
         this.wins = wins;
     }
 
-    public int getMmr() {
-        return mmr;
+    public int getXp() { // Renamed from getMmr to getXp
+        return xp;
     }
 
-    public void setMmr(int mmr) {
-        this.mmr = mmr;
+    public void setXp(int xp) { // Renamed from setMmr to setXp
+        this.xp = xp;
     }
 
     public int getPoints() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -52,7 +52,7 @@ public class DTOMapper {
         // Build profile
         UserProfile profile = new UserProfile();
         profile.setUsername(dto.getUsername());
-        profile.setMmr(0); // default
+        profile.setXp(0); // default
         profile.setAchievements(new ArrayList<>());
         user.setProfile(profile);
 
@@ -75,7 +75,7 @@ public class DTOMapper {
         dto.setUserid(user.getId());
         dto.setUsername(user.getProfile().getUsername());
         dto.setToken(user.getToken());
-        dto.setPoints(user.getProfile().getMmr()); // interpret "points" as mmr
+        dto.setPoints(user.getProfile().getXp()); // interpret "points" as xp
         return dto;
     }
 
@@ -94,7 +94,7 @@ public class DTOMapper {
         UserPublicDTO dto = new UserPublicDTO();
         dto.setUserid(user.getId());
         dto.setUsername(user.getProfile().getUsername());
-        dto.setMmr(user.getProfile().getMmr());
+        dto.setXp(user.getProfile().getXp());
         dto.setAchievements(user.getProfile().getAchievements());
         dto.setEmail(user.getEmail());
         return dto;
@@ -122,7 +122,7 @@ public class DTOMapper {
         UserStatsDTO dto = new UserStatsDTO();
         dto.setGamesPlayed(user.getProfile().getGamesPlayed());
         dto.setWins(user.getProfile().getWins());
-        dto.setMmr(user.getProfile().getMmr());
+        dto.setXp(user.getProfile().getXp());
         return dto;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserXpService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserXpService.java
@@ -1,0 +1,148 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs24.websocket.dto.PlayerXpUpdateDTO;
+
+@Service
+@Transactional
+public class UserXpService {
+    
+    private static final Logger log = LoggerFactory.getLogger(UserXpService.class);
+    
+    // XP Constants
+    public static final int XP_FOR_GUESS = 10;
+    public static final int XP_FOR_ROUND_WIN = 20;
+    public static final int XP_FOR_GAME_WIN = 50;
+    
+    private final UserRepository userRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+    
+    @Autowired
+    public UserXpService(UserRepository userRepository, SimpMessagingTemplate messagingTemplate) {
+        this.userRepository = userRepository;
+        this.messagingTemplate = messagingTemplate;
+    }
+    
+    /**
+     * Award XP to a user for making a guess
+     * @param user The user who made the guess
+     */
+    public void awardXpForGuess(User user) {
+        awardXp(user, XP_FOR_GUESS, "Made a guess");
+    }
+    
+    /**
+     * Award XP to a user for winning a round
+     * @param user The user who won the round
+     */
+    public void awardXpForRoundWin(User user) {
+        awardXp(user, XP_FOR_ROUND_WIN, "Won a round");
+    }
+    
+    /**
+     * Award XP to a user for winning a game
+     * @param user The user who won the game
+     */
+    public void awardXpForGameWin(User user) {
+        awardXp(user, XP_FOR_GAME_WIN, "Won a game");
+    }
+    
+    /**
+     * Award XP to a user and send a WebSocket notification
+     * @param user The user to award XP to
+     * @param xpAmount The amount of XP to award
+     * @param reason The reason for the XP award
+     */
+    @Transactional
+    public void awardXp(User user, int xpAmount, String reason) {
+        if (user == null) {
+            log.warn("Attempted to award XP to null user");
+            return;
+        }
+        
+        if (user.getToken() == null) {
+            log.warn("User {} has no token, cannot send XP notification", user.getId());
+            return;
+        }
+        
+        int currentXp = user.getProfile().getXp();
+        int newXp = currentXp + xpAmount;
+        
+        // Update XP in database
+        user.getProfile().setXp(newXp);
+        userRepository.save(user);
+        
+        log.info("Awarded {} XP to user {} ({}). New total: {}", 
+            xpAmount, user.getId(), user.getProfile().getUsername(), newXp);
+        
+        // Send WebSocket notification
+        PlayerXpUpdateDTO xpUpdateDTO = new PlayerXpUpdateDTO(
+            user.getProfile().getUsername(),
+            user.getId(),
+            xpAmount,
+            newXp,
+            reason
+        );
+        
+        // Send to the specific user
+        messagingTemplate.convertAndSendToUser(
+            user.getToken(),
+            "/queue/xp-updates",
+            xpUpdateDTO
+        );
+    }
+    
+    /**
+     * Sends an XP update notification to a user via WebSocket
+     */
+    public void sendXpUpdateNotification(User user, int xpGained, int totalXp, String reason) {
+        if (user == null || user.getToken() == null) {
+            log.warn("Cannot send XP notification to user with null token");
+            return;
+        }
+        
+        try {
+            PlayerXpUpdateDTO xpUpdateDTO = new PlayerXpUpdateDTO(
+                user.getProfile().getUsername(),
+                user.getId(),
+                xpGained,
+                totalXp,
+                reason
+            );
+            
+            // Send to the specific user
+            messagingTemplate.convertAndSendToUser(
+                user.getToken(),
+                "/queue/xp-updates",
+                xpUpdateDTO
+            );
+            
+            log.debug("Sent XP update notification to user {}: +{} XP", 
+                user.getId(), xpGained);
+        } catch (Exception e) {
+            log.error("Failed to send XP update notification: {}", e.getMessage(), e);
+        }
+    }
+    
+    /**
+     * Get current XP for a user and send a notification
+     * This can be called when a user requests their current XP
+     */
+    public void sendCurrentXpNotification(User user) {
+        if (user == null) {
+            log.warn("Cannot send current XP notification to null user");
+            return;
+        }
+        
+        int currentXp = user.getProfile().getXp();
+        sendXpUpdateNotification(user, 0, currentXp, "XP status request");
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/PlayerXpUpdateDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/PlayerXpUpdateDTO.java
@@ -1,0 +1,45 @@
+package ch.uzh.ifi.hase.soprafs24.websocket.dto;
+
+/**
+ * DTO for sending XP updates to players
+ */
+public class PlayerXpUpdateDTO {
+    private final String type = "XP_UPDATE";
+    private final String username;
+    private final Long userId;
+    private final int xpGained;
+    private final int totalXp;
+    private final String reason;
+
+    public PlayerXpUpdateDTO(String username, Long userId, int xpGained, int totalXp, String reason) {
+        this.username = username;
+        this.userId = userId;
+        this.xpGained = xpGained;
+        this.totalXp = totalXp;
+        this.reason = reason;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public int getXpGained() {
+        return xpGained;
+    }
+
+    public int getTotalXp() {
+        return totalXp;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/XpUpdateMessage.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/websocket/dto/XpUpdateMessage.java
@@ -1,0 +1,29 @@
+package ch.uzh.ifi.hase.soprafs24.websocket.dto;
+
+/**
+ * DTO for sending XP updates to the client via WebSocket.
+ * Used to notify clients when they earn XP in the game.
+ */
+public class XpUpdateMessage {
+    private final int totalXp;
+    private final int xpGained;
+    private final String reason;
+
+    public XpUpdateMessage(int totalXp, int xpGained, String reason) {
+        this.totalXp = totalXp;
+        this.xpGained = xpGained;
+        this.reason = reason;
+    }
+
+    public int getTotalXp() {
+        return totalXp;
+    }
+
+    public int getXpGained() {
+        return xpGained;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/StatsControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/StatsControllerTest.java
@@ -59,7 +59,7 @@ public class StatsControllerTest {
 
         UserProfile profile = new UserProfile();
         profile.setUsername("testUser");
-        profile.setMmr(1500);
+        profile.setXp(1500);  // Changed from setMmr to setXp
         profile.setPoints(1500);
         profile.setWins(5);
         profile.setGamesPlayed(7); // Added this since there's no setter for losses directly
@@ -71,7 +71,7 @@ public class StatsControllerTest {
         UserStatsDTO statsDTO = new UserStatsDTO();
         statsDTO.setGamesPlayed(7);
         statsDTO.setWins(5);
-        statsDTO.setMmr(1500);
+        statsDTO.setXp(1500);  // Changed from setMmr to setXp
         statsDTO.setPoints(1500);
 
         given(userService.getPublicProfile(eq(1L))).willReturn(user);
@@ -83,7 +83,7 @@ public class StatsControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.gamesPlayed").value(7))
                 .andExpect(jsonPath("$.wins").value(5))
-                .andExpect(jsonPath("$.mmr").value(1500))
+                .andExpect(jsonPath("$.xp").value(1500))  // Changed from $.mmr to $.xp
                 .andExpect(jsonPath("$.points").value(1500));
     }
 
@@ -105,7 +105,7 @@ public class StatsControllerTest {
 
         UserProfile profile = new UserProfile();
         profile.setUsername("testUser");
-        profile.setMmr(1500);
+        profile.setXp(1500);  // Changed from setMmr to setXp
         profile.setStatsPublic(false); // Private stats
         user.setProfile(profile);
 
@@ -136,7 +136,7 @@ public class StatsControllerTest {
 
         UserProfile profile = new UserProfile();
         profile.setUsername("testUser");
-        profile.setMmr(1500);
+        profile.setXp(1500);  // Changed from setMmr to setXp
         profile.setPoints(1500);
         profile.setWins(5);
         profile.setGamesPlayed(7);
@@ -147,7 +147,7 @@ public class StatsControllerTest {
         UserStatsDTO statsDTO = new UserStatsDTO();
         statsDTO.setGamesPlayed(7);
         statsDTO.setWins(5);
-        statsDTO.setMmr(1500);
+        statsDTO.setXp(1500);  // Changed from setMmr to setXp
         statsDTO.setPoints(1500);
 
         given(authService.getUserByToken(eq(token))).willReturn(user);
@@ -160,7 +160,7 @@ public class StatsControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.gamesPlayed").value(7))
                 .andExpect(jsonPath("$.wins").value(5))
-                .andExpect(jsonPath("$.mmr").value(1500))
+                .andExpect(jsonPath("$.xp").value(1500))  // Changed from $.mmr to $.xp
                 .andExpect(jsonPath("$.points").value(1500));
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
@@ -66,7 +66,7 @@ public class UserControllerTest {
 
         UserProfile profile = new UserProfile();
         profile.setUsername("firstnameLastname");
-        profile.setMmr(1500);
+        profile.setXp(1500); // Changed from setMmr to setXp
         profile.setPoints(1500); // Add points to match the DTO
         profile.setAchievements(Arrays.asList("First Win"));
         user.setProfile(profile);
@@ -75,7 +75,7 @@ public class UserControllerTest {
         UserPublicDTO publicDTO = new UserPublicDTO();
         publicDTO.setUserid(1L);
         publicDTO.setUsername(profile.getUsername());
-        publicDTO.setMmr(profile.getMmr());
+        publicDTO.setXp(profile.getXp()); // Changed from setMmr/getMmr to setXp/getXp
         publicDTO.setPoints(profile.getPoints()); // Set points to be returned
         publicDTO.setEmail(user.getEmail());
         // No need to set achievements as they are @JsonIgnore'd
@@ -90,7 +90,7 @@ public class UserControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.userid", is(1)))
             .andExpect(jsonPath("$.username", is(profile.getUsername())))
-            .andExpect(jsonPath("$.mmr", is(profile.getMmr())))
+            .andExpect(jsonPath("$.xp", is(profile.getXp()))) // Changed from mmr to xp
             .andExpect(jsonPath("$.points", is(profile.getPoints())))
             .andExpect(jsonPath("$.email", is(user.getEmail())));
             // Remove the assertion for $.achievements since it's @JsonIgnore'd in UserPublicDTO

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/UserRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/repository/UserRepositoryIntegrationTest.java
@@ -38,7 +38,7 @@ public class UserRepositoryIntegrationTest {
     
     UserProfile profile = new UserProfile();
     profile.setUsername("Firstname Lastname");
-    profile.setMmr(1500);
+    profile.setXp(1500);  // Changed from setMmr to setXp
     profile.setAchievements(Arrays.asList("Achievement1", "Achievement2"));
     // You can set other profile fields if necessary.
     user.setProfile(profile);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPublicDTOTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPublicDTOTest.java
@@ -18,7 +18,7 @@ class UserPublicDTOTest {
         userPublicDTO = new UserPublicDTO();
         userPublicDTO.setUserid(1L);
         userPublicDTO.setUsername("testUser");
-        userPublicDTO.setMmr(1500);
+        userPublicDTO.setXp(1500);  // Changed from setMmr to setXp
         userPublicDTO.setPoints(1500);
         userPublicDTO.setAchievements(testAchievements);
         userPublicDTO.setEmail("test@example.com");
@@ -28,7 +28,7 @@ class UserPublicDTOTest {
     void testGettersAndSetters() {
         assertEquals(1L, userPublicDTO.getUserid());
         assertEquals("testUser", userPublicDTO.getUsername());
-        assertEquals(1500, userPublicDTO.getMmr());
+        assertEquals(1500, userPublicDTO.getXp());  // Changed from getMmr to getXp
         assertEquals(1500, userPublicDTO.getPoints());
         assertEquals(testAchievements, userPublicDTO.getAchievements());
         assertEquals("test@example.com", userPublicDTO.getEmail());
@@ -37,14 +37,14 @@ class UserPublicDTOTest {
         List<String> newAchievements = Arrays.asList("Tournament Win", "MVP");
         userPublicDTO.setUserid(2L);
         userPublicDTO.setUsername("publicUser");
-        userPublicDTO.setMmr(1600);
+        userPublicDTO.setXp(1600);  // Changed from setMmr to setXp
         userPublicDTO.setPoints(1600);
         userPublicDTO.setAchievements(newAchievements);
         userPublicDTO.setEmail("public@example.com");
         
         assertEquals(2L, userPublicDTO.getUserid());
         assertEquals("publicUser", userPublicDTO.getUsername());
-        assertEquals(1600, userPublicDTO.getMmr());
+        assertEquals(1600, userPublicDTO.getXp());  // Changed from getMmr to getXp
         assertEquals(1600, userPublicDTO.getPoints());
         assertEquals(newAchievements, userPublicDTO.getAchievements());
         assertEquals("public@example.com", userPublicDTO.getEmail());
@@ -55,7 +55,7 @@ class UserPublicDTOTest {
         UserPublicDTO dto = new UserPublicDTO();
         assertNull(dto.getUserid());
         assertNull(dto.getUsername());
-        assertEquals(0, dto.getMmr());
+        assertEquals(0, dto.getXp());  // Changed from getMmr to getXp
         assertEquals(0, dto.getPoints());
         assertNull(dto.getAchievements());
         assertNull(dto.getEmail());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserStatsDTOTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserStatsDTOTest.java
@@ -14,7 +14,7 @@ class UserStatsDTOTest {
         userStatsDTO = new UserStatsDTO();
         userStatsDTO.setGamesPlayed(10);
         userStatsDTO.setWins(5);
-        userStatsDTO.setMmr(1500);
+        userStatsDTO.setXp(1500);  // Changed from setMmr to setXp
         userStatsDTO.setPoints(1500);
     }
 
@@ -22,18 +22,18 @@ class UserStatsDTOTest {
     void testGettersAndSetters() {
         assertEquals(10, userStatsDTO.getGamesPlayed());
         assertEquals(5, userStatsDTO.getWins());
-        assertEquals(1500, userStatsDTO.getMmr());
+        assertEquals(1500, userStatsDTO.getXp());  // Changed from getMmr to getXp
         assertEquals(1500, userStatsDTO.getPoints());
         
         // Test changing values
         userStatsDTO.setGamesPlayed(15);
         userStatsDTO.setWins(8);
-        userStatsDTO.setMmr(1600);
+        userStatsDTO.setXp(1600);  // Changed from setMmr to setXp
         userStatsDTO.setPoints(1600);
         
         assertEquals(15, userStatsDTO.getGamesPlayed());
         assertEquals(8, userStatsDTO.getWins());
-        assertEquals(1600, userStatsDTO.getMmr());
+        assertEquals(1600, userStatsDTO.getXp());  // Changed from getMmr to getXp
         assertEquals(1600, userStatsDTO.getPoints());
     }
     
@@ -42,7 +42,7 @@ class UserStatsDTOTest {
         UserStatsDTO dto = new UserStatsDTO();
         assertEquals(0, dto.getGamesPlayed());
         assertEquals(0, dto.getWins());
-        assertEquals(0, dto.getMmr());
+        assertEquals(0, dto.getXp());  // Changed from getMmr to getXp
         assertEquals(0, dto.getPoints());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapperTest.java
@@ -63,7 +63,7 @@ public class DTOMapperTest {
 
         UserProfile profile = new UserProfile();
         profile.setUsername("dummyUser");
-        profile.setMmr(1500);
+        profile.setXp(1500); // Changed from setMmr to setXp
         profile.setAchievements(Arrays.asList("First Win", "Sharp Shooter"));
         profile.setFriends(new ArrayList<>());
         profile.setStatsPublic(true);
@@ -83,7 +83,7 @@ public class DTOMapperTest {
         assertEquals(registerDTO.getEmail(), newUser.getEmail());
         assertEquals(registerDTO.getPassword(), newUser.getPassword());
         // defaults
-        assertEquals(0, newUser.getProfile().getMmr());
+        assertEquals(0, newUser.getProfile().getXp()); // Changed from getMmr() to getXp()
         assertNotNull(newUser.getProfile().getAchievements());
     }
 
@@ -105,8 +105,8 @@ public class DTOMapperTest {
         assertEquals(dummyUser.getId(), loginDTO.getUserid());
         assertEquals(dummyUser.getProfile().getUsername(), loginDTO.getUsername());
         assertEquals(dummyUser.getToken(), loginDTO.getToken());
-        // points interpreted as mmr
-        assertEquals(dummyUser.getProfile().getMmr(), loginDTO.getPoints());
+        // points interpreted as xp now
+        assertEquals(dummyUser.getProfile().getXp(), loginDTO.getPoints()); // Changed from getMmr() to getXp()
     }
 
     @Test
@@ -125,7 +125,7 @@ public class DTOMapperTest {
 
         assertEquals(dummyUser.getId(), publicDTO.getUserid());
         assertEquals(dummyUser.getProfile().getUsername(), publicDTO.getUsername());
-        assertEquals(dummyUser.getProfile().getMmr(), publicDTO.getMmr());
+        assertEquals(dummyUser.getProfile().getXp(), publicDTO.getXp()); // Changed from getMmr()/getMmr() to getXp()/getXp()
         assertEquals(dummyUser.getProfile().getAchievements(), publicDTO.getAchievements());
     }
 
@@ -156,13 +156,13 @@ public class DTOMapperTest {
     public void testToUserStatsDTO() {
         dummyUser.getProfile().setGamesPlayed(20);
         dummyUser.getProfile().setWins(12);
-        dummyUser.getProfile().setMmr(1550);
+        dummyUser.getProfile().setXp(1550); // Changed from setMmr() to setXp()
 
         UserStatsDTO statsDTO = mapper.toUserStatsDTO(dummyUser);
 
         assertEquals(20, statsDTO.getGamesPlayed());
         assertEquals(12, statsDTO.getWins());
-        assertEquals(1550, statsDTO.getMmr());
+        assertEquals(1550, statsDTO.getXp()); // Changed from getMmr() to getXp()
     }
     // New tests for Lobby DTO mappings to comply with solo/team modes
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceIntegrationTest.java
@@ -100,7 +100,7 @@ public class LobbyServiceIntegrationTest {
         UserProfile hostProfile = new UserProfile();
         hostProfile.setUsername("HostUser");
         hostProfile.setStatsPublic(true);
-        hostProfile.setMmr(0);
+        hostProfile.setXp(0);  // Updated to use XP instead of MMR
         hostProfile.setAchievements(new ArrayList<>());
         hostUser.setProfile(hostProfile);
         
@@ -197,7 +197,7 @@ public class LobbyServiceIntegrationTest {
         UserProfile joinerProfile = new UserProfile();
         joinerProfile.setUsername("JoiningUser");
         joinerProfile.setStatsPublic(true);
-        joinerProfile.setMmr(0);
+        joinerProfile.setXp(0);  // Updated to use XP instead of MMR
         joinerProfile.setAchievements(new ArrayList<>());
         joiningUser.setProfile(joinerProfile);
         
@@ -240,7 +240,7 @@ public class LobbyServiceIntegrationTest {
         UserProfile joinerProfile = new UserProfile();
         joinerProfile.setUsername("FriendUser");
         joinerProfile.setStatsPublic(true);
-        joinerProfile.setMmr(0);
+        joinerProfile.setXp(0);  // Updated to use XP instead of MMR
         joinerProfile.setAchievements(new ArrayList<>());
         joiningUser.setProfile(joinerProfile);
         
@@ -277,7 +277,7 @@ public class LobbyServiceIntegrationTest {
         UserProfile joinerProfile = new UserProfile();
         joinerProfile.setUsername("JoiningUser2");
         joinerProfile.setStatsPublic(true);
-        joinerProfile.setMmr(0);
+        joinerProfile.setXp(0);  // Updated to use XP instead of MMR
         joinerProfile.setAchievements(new ArrayList<>());
         joiningUser.setProfile(joinerProfile);
         
@@ -318,7 +318,7 @@ public class LobbyServiceIntegrationTest {
         UserProfile joinerProfile = new UserProfile();
         joinerProfile.setUsername("JoiningUser3");
         joinerProfile.setStatsPublic(true);
-        joinerProfile.setMmr(0);
+        joinerProfile.setXp(0);  // Updated to use XP instead of MMR
         joinerProfile.setAchievements(new ArrayList<>());
         joiningUser.setProfile(joinerProfile);
         

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserServiceIntegrationTest.java
@@ -82,7 +82,7 @@ public class UserServiceIntegrationTest {
     UserProfile profile = new UserProfile();
     profile.setUsername("originalUsername");
     profile.setStatsPublic(false); // Initialize with a value
-    profile.setMmr(1000);          // Initialize with a default MMR
+    profile.setXp(1000);          // Initialize with a default XP (changed from mmr)
     profile.setGamesPlayed(0);     // Initialize games played
     profile.setWins(0);            // Initialize wins
     profile.setAchievements(new ArrayList<>()); // Initialize empty achievements list
@@ -120,7 +120,7 @@ public class UserServiceIntegrationTest {
     UserProfile profile1 = new UserProfile();
     profile1.setUsername("duplicateUsername");
     profile1.setStatsPublic(true);        // Initialize with a value
-    profile1.setMmr(1000);                // Initialize with a default MMR
+    profile1.setXp(1000);                // Initialize with a default XP value
     profile1.setGamesPlayed(0);           // Initialize games played
     profile1.setWins(0);                  // Initialize wins 
     profile1.setAchievements(new ArrayList<>()); // Initialize empty achievements list
@@ -137,7 +137,7 @@ public class UserServiceIntegrationTest {
     UserProfile profile2 = new UserProfile();
     profile2.setUsername("uniqueUsername");
     profile2.setStatsPublic(false);       // Initialize with a value
-    profile2.setMmr(1000);                // Initialize with a default MMR
+    profile2.setXp(1000);                // Initialize with a default XP value
     profile2.setGamesPlayed(0);           // Initialize games played
     profile2.setWins(0);                  // Initialize wins
     profile2.setAchievements(new ArrayList<>()); // Initialize empty achievements list
@@ -156,5 +156,43 @@ public class UserServiceIntegrationTest {
     });
     // Expect a conflict error (HTTP 409).
     assertEquals(409, exception.getStatus().value());
+  }
+
+  @Test
+  public void userXpAwarded_persistsCorrectly() {
+    // Create a test user
+    User testUser = new User();
+    testUser.setEmail("xptest@example.com");
+    testUser.setPassword("password");
+    testUser.setStatus(UserStatus.OFFLINE);
+    
+    UserProfile profile = new UserProfile();
+    profile.setUsername("xpTestUser");
+    profile.setStatsPublic(true);
+    profile.setXp(0);  // Start with 0 XP
+    profile.setGamesPlayed(0);
+    profile.setWins(0);
+    profile.setAchievements(new ArrayList<>());
+    testUser.setProfile(profile);
+    testUser.setToken("xp-test-token");
+    
+    userRepository.save(testUser);
+    userRepository.flush();
+    
+    // Get the saved user ID
+    Long userId = testUser.getId();
+    
+    // Use UserXpService to award XP (if it's available in the test context)
+    // Note: This might need to be mocked or autowired depending on your test setup
+    
+    // Directly update XP for test purposes
+    testUser.getProfile().setXp(50);
+    userRepository.save(testUser);
+    userRepository.flush();
+    
+    // Verify XP was persisted
+    User updatedUser = userRepository.findById(userId).orElse(null);
+    assertNotNull(updatedUser);
+    assertEquals(50, updatedUser.getProfile().getXp());
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserXpServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/UserXpServiceTest.java
@@ -1,0 +1,113 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.entity.UserProfile;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs24.websocket.dto.PlayerXpUpdateDTO;
+
+public class UserXpServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+    
+    @InjectMocks
+    private UserXpService userXpService;
+    
+    private User testUser;
+    private static final String TEST_TOKEN = "test-token";
+    
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        
+        // Create test user
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setToken(TEST_TOKEN);
+        
+        // Create user profile
+        UserProfile profile = new UserProfile();
+        profile.setUsername("testUser");
+        profile.setXp(100);
+        testUser.setProfile(profile);
+        
+        // Mock repository save
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+    }
+    
+    @Test
+    public void testAwardXp_IncrementsUserXp() {
+        // Initial XP
+        int initialXp = testUser.getProfile().getXp();
+        int xpToAward = 20;
+        
+        // Call the method
+        userXpService.awardXp(testUser, xpToAward, "Test reason");
+        
+        // Verify XP was updated
+        assertEquals(initialXp + xpToAward, testUser.getProfile().getXp());
+        
+        // Verify user was saved to repository
+        verify(userRepository, times(1)).save(eq(testUser));
+        
+        // Verify notification was sent
+        verify(messagingTemplate, times(1)).convertAndSendToUser(
+            eq(TEST_TOKEN),
+            eq("/queue/xp-updates"),
+            any(PlayerXpUpdateDTO.class)
+        );
+    }
+    
+    @Test
+    public void testAwardXpForGuess_UsesCorrectXpAmount() {
+        userXpService.awardXpForGuess(testUser);
+        
+        // Verify XP was updated with correct amount
+        assertEquals(100 + UserXpService.XP_FOR_GUESS, testUser.getProfile().getXp());
+    }
+    
+    @Test
+    public void testAwardXpForRoundWin_UsesCorrectXpAmount() {
+        userXpService.awardXpForRoundWin(testUser);
+        
+        // Verify XP was updated with correct amount
+        assertEquals(100 + UserXpService.XP_FOR_ROUND_WIN, testUser.getProfile().getXp());
+    }
+    
+    @Test
+    public void testAwardXpForGameWin_UsesCorrectXpAmount() {
+        userXpService.awardXpForGameWin(testUser);
+        
+        // Verify XP was updated with correct amount
+        assertEquals(100 + UserXpService.XP_FOR_GAME_WIN, testUser.getProfile().getXp());
+    }
+    
+    @Test
+    public void testSendCurrentXpNotification_SendsCorrectData() {
+        userXpService.sendCurrentXpNotification(testUser);
+        
+        // Verify notification was sent with correct data
+        verify(messagingTemplate, times(1)).convertAndSendToUser(
+            eq(TEST_TOKEN),
+            eq("/queue/xp-updates"),
+            any(PlayerXpUpdateDTO.class)
+        );
+    }
+}


### PR DESCRIPTION
…send the update message via the WS. Tasks #145, #146, #147

### Related Issues

Closes #145, Closes #146, Closes #147

### Changes

- Instead of MMR we will use the XP. 
- The XPs are applied through the web socket in a dedicated message. The logic is added to the corresponding server and controller implementations. The DTOs are updated respectively.
- For an exhaustive description and example of integration on the client side, check the doc file via [link](https://docs.google.com/document/d/1L3sT1jBssKT0Anr_UlSedYwKnfMlpqv-tgYnIGWFHdU/edit?usp=sharing)
- The client will receive XP updates automatically after certain actions:
Making a guess (+10 XP)
Winning a round (+20 XP)
Winning a game (+50 XP)
