### PR TITLE
Feat/leaderboards and player history

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
     id 'idea'
     id 'jacoco'
-    id "org.sonarqube" version "4.4.1.3373"
+    id 'org.sonarqube' version '4.4.1.3373'
     id 'io.freefair.lombok' version '6.6.3'
 }
 
@@ -16,6 +16,7 @@ java {
         languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
+
 dependencyManagement {
     imports {
         mavenBom "com.google.cloud:spring-cloud-gcp-dependencies:4.0.0"
@@ -44,12 +45,11 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
-    // implementation 'com.google.cloud.sql:postgres-socket-factory:1.25.0' // Cloud SQL JDBC Socket Factory :contentReference[oaicite:2]{index=2}
+
     // Spring & WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework:spring-messaging'
-
 
     // MapStruct
     implementation 'org.mapstruct:mapstruct:1.3.1.Final'
@@ -72,8 +72,7 @@ dependencies {
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.6'
     implementation 'com.google.cloud:spring-cloud-gcp-starter-sql-postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    // implementation 'com.google.cloud.sql:postgres-socket-factory:1.25.0'
-    // implementation 'com.google.cloud.sql:jdbc-socket-factory-core:1.25.0'
+
     // Testing
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
@@ -81,9 +80,6 @@ dependencies {
     // H2 runtime/test dependencies
     runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'com.h2database:h2'
-
-    // Make sure H2 is available for tests
-    testImplementation 'com.h2database:h2'
 }
 
 bootJar {
@@ -129,3 +125,22 @@ if (secretPropsFile.exists()) {
 }
 
 defaultTasks 'bootJar', 'build'
+
+// ------------------------------------------------
+// Task to run the application in DEV mode via JavaExec
+// ------------------------------------------------
+task devRun(type: JavaExec) {
+    group = 'application'
+    description = 'Launch Spring Boot with the dev profile (H2, no GCP SQL)'
+
+    // Use the main class and runtime classpath
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'ch.uzh.ifi.hase.soprafs24.Application'
+
+    // Activate the dev profile so Spring picks up all %dev.* props
+    systemProperty 'spring.profiles.active', 'dev'
+
+    // Ensure the Cloud-SQL auto-config is off for dev
+    systemProperty 'spring.cloud.gcp.sql.enabled', 'false'
+    systemProperty 'spring.cloud.gcp.sql.jdbc.enabled', 'false'
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/StatsController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/StatsController.java
@@ -1,5 +1,7 @@
 package ch.uzh.ifi.hase.soprafs24.controller;
 
+import java.util.stream.Collectors;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -8,8 +10,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
+import java.util.List; 
 import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LeaderboardDTO;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.LeaderboardEntryDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.UserStatsDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs24.service.AuthService;
@@ -53,5 +57,15 @@ public class StatsController {
     public UserStatsDTO getMyStats(@RequestHeader("Authorization") String token) {
         User user = authService.getUserByToken(token);
         return mapper.toUserStatsDTO(user);
+    }
+
+    @GetMapping("/leaderboard")
+    @ResponseStatus(HttpStatus.OK)
+    public LeaderboardDTO getLeaderboard() {
+        List<User> top10 = userService.getTopPlayersByMmr(10);
+        List<LeaderboardEntryDTO> entries = top10.stream()
+            .map(mapper::toLeaderboardEntryDTO)
+            .collect(Collectors.toList());
+        return new LeaderboardDTO(entries);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/GameRecord.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/GameRecord.java
@@ -1,0 +1,70 @@
+package ch.uzh.ifi.hase.soprafs24.entity;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "GAME_RECORD")
+public class GameRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // link back to the user who this record belongs to
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String winner;
+
+    // one row per player in a separate table
+    @ElementCollection
+    @CollectionTable(
+        name = "GAME_RECORD_PLAYERS",
+        joinColumns = @JoinColumn(name = "game_record_id")
+    )
+    @Column(name = "player", nullable = false)
+    private List<String> players;
+
+    @Column(nullable = false)
+    private int roundsPlayed;
+
+    @Column(nullable = false)
+    private int roundCardStartAmount;
+
+    @Column(nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime completedAt;
+
+    // --- getters & setters ---
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public String getWinner() { return winner; }
+    public void setWinner(String winner) { this.winner = winner; }
+
+    public List<String> getPlayers() { return players; }
+    public void setPlayers(List<String> players) { this.players = players; }
+
+    public int getRoundsPlayed() { return roundsPlayed; }
+    public void setRoundsPlayed(int roundsPlayed) { this.roundsPlayed = roundsPlayed; }
+
+    public int getRoundCardStartAmount() { return roundCardStartAmount; }
+    public void setRoundCardStartAmount(int roundCardStartAmount) {
+        this.roundCardStartAmount = roundCardStartAmount;
+    }
+
+    public LocalDateTime getStartedAt() { return startedAt; }
+    public void setStartedAt(LocalDateTime startedAt) { this.startedAt = startedAt; }
+
+    public LocalDateTime getCompletedAt() { return completedAt; }
+    public void setCompletedAt(LocalDateTime completedAt) { this.completedAt = completedAt; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/UserProfile.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/UserProfile.java
@@ -116,4 +116,9 @@ public class UserProfile implements Serializable {
     public void setBiography(String biography) {
         this.biography = biography;
     }
+    @Column(nullable = false)
+    private int winStreak = 0;
+
+    public int getWinStreak() { return winStreak; }
+    public void setWinStreak(int winStreak) { this.winStreak = winStreak; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/GameRecordRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/GameRecordRepository.java
@@ -1,0 +1,13 @@
+
+package ch.uzh.ifi.hase.soprafs24.repository;
+
+import ch.uzh.ifi.hase.soprafs24.entity.GameRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GameRecordRepository extends JpaRepository<GameRecord, Long> {
+    List<GameRecord> findByUserId(Long userId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/GameRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/GameRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 @Repository("gameRepository")
 public interface GameRepository extends JpaRepository<Game, Long> {
-
+    Game findTopByPlayers_IdOrderByCreationDateDesc(Long userId);
     Optional<Game> findById(Long id);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/UserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/repository/UserRepository.java
@@ -1,5 +1,5 @@
 package ch.uzh.ifi.hase.soprafs24.repository;
-
+import java.util.List; 
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // Lookup via email and token:
     User findByEmail(String email);
     User findByToken(String token);
+    List<User> findTop10ByOrderByProfileMmrDesc();
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/GameRecordDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/GameRecordDTO.java
@@ -1,0 +1,33 @@
+// src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/GameRecordDTO.java
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GameRecordDTO {
+    private String winner;
+    private List<String> players;
+    private int roundsPlayed;
+    private int roundCardStartAmount;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+
+    // getters & setters
+    public String getWinner() { return winner; }
+    public void setWinner(String winner) { this.winner = winner; }
+
+    public List<String> getPlayers() { return players; }
+    public void setPlayers(List<String> players) { this.players = players; }
+
+    public int getRoundsPlayed() { return roundsPlayed; }
+    public void setRoundsPlayed(int roundsPlayed) { this.roundsPlayed = roundsPlayed; }
+
+    public int getRoundCardStartAmount() { return roundCardStartAmount; }
+    public void setRoundCardStartAmount(int roundCardStartAmount) { this.roundCardStartAmount = roundCardStartAmount; }
+
+    public LocalDateTime getStartedAt() { return startedAt; }
+    public void setStartedAt(LocalDateTime startedAt) { this.startedAt = startedAt; }
+
+    public LocalDateTime getCompletedAt() { return completedAt; }
+    public void setCompletedAt(LocalDateTime completedAt) { this.completedAt = completedAt; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LeaderboardDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LeaderboardDTO.java
@@ -1,0 +1,16 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+import java.util.List;
+
+public class LeaderboardDTO {
+    private List<LeaderboardEntryDTO> entries;
+
+    public LeaderboardDTO() {}
+
+    public LeaderboardDTO(List<LeaderboardEntryDTO> entries) {
+        this.entries = entries;
+    }
+
+    public List<LeaderboardEntryDTO> getEntries() { return entries; }
+    public void setEntries(List<LeaderboardEntryDTO> entries) { this.entries = entries; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LeaderboardEntryDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/LeaderboardEntryDTO.java
@@ -1,0 +1,19 @@
+package ch.uzh.ifi.hase.soprafs24.rest.dto;
+
+public class LeaderboardEntryDTO {
+    private String username;
+    private int mmr;
+
+    public LeaderboardEntryDTO() {}
+
+    public LeaderboardEntryDTO(String username, int mmr) {
+        this.username = username;
+        this.mmr = mmr;
+    }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public int getMmr() { return mmr; }
+    public void setMmr(int mmr) { this.mmr = mmr; }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserStatsDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserStatsDTO.java
@@ -1,9 +1,15 @@
 package ch.uzh.ifi.hase.soprafs24.rest.dto;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class UserStatsDTO {
     private int gamesPlayed;
     private int wins;
     private int mmr;
+    private int winStreak;
+    private List<String> lastGamePlayers;
+    private String lastGameWinner;
+
     private int points;
 
     public int getGamesPlayed() {
@@ -36,5 +42,26 @@ public class UserStatsDTO {
 
     public void setPoints(int points) {
         this.points = points;
+    }
+
+    public int getWinStreak() {
+        return winStreak;
+    }
+    public void setWinStreak(int winStreak) {
+        this.winStreak = winStreak;
+    }
+    
+    public List<String> getLastGamePlayers() {
+        return lastGamePlayers;
+    }
+    public void setLastGamePlayers(List<String> lastGamePlayers) {
+        this.lastGamePlayers = lastGamePlayers;
+    }
+    
+    public String getLastGameWinner() {
+        return lastGameWinner;
+    }
+    public void setLastGameWinner(String lastGameWinner) {
+        this.lastGameWinner = lastGameWinner;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/StatsService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/StatsService.java
@@ -1,0 +1,11 @@
+
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.rest.dto.GameRecordDTO;
+import java.util.List;
+
+public interface StatsService {
+    void saveGameRecord(Long userId, GameRecordDTO record);
+    List<GameRecordDTO> getGameRecords(Long userId);
+
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/StatsServiceImpl.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/StatsServiceImpl.java
@@ -1,0 +1,62 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import ch.uzh.ifi.hase.soprafs24.entity.GameRecord;
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.repository.GameRecordRepository;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs24.rest.dto.GameRecordDTO;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of StatsService, handling persistence and retrieval of game records.
+ */
+@Service
+@Transactional
+public class StatsServiceImpl implements StatsService {
+
+    private final GameRecordRepository recordRepo;
+    private final UserRepository        userRepo;
+
+    public StatsServiceImpl(GameRecordRepository recordRepo,
+                            UserRepository userRepo) {
+        this.recordRepo = recordRepo;
+        this.userRepo   = userRepo;
+    }
+
+    @Override
+    public void saveGameRecord(Long userId, GameRecordDTO dto) {
+        User user = userRepo.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+        GameRecord record = new GameRecord();
+        record.setUser(user);
+        record.setWinner(dto.getWinner());
+        record.setPlayers(dto.getPlayers());
+        record.setRoundsPlayed(dto.getRoundsPlayed());
+        record.setRoundCardStartAmount(dto.getRoundCardStartAmount());
+        record.setStartedAt(dto.getStartedAt());
+        record.setCompletedAt(dto.getCompletedAt());
+
+        recordRepo.save(record);
+    }
+
+    @Override
+    public List<GameRecordDTO> getGameRecords(Long userId) {
+        return recordRepo.findByUserId(userId).stream()
+            .map(rec -> {
+                GameRecordDTO dto = new GameRecordDTO();
+                dto.setWinner(rec.getWinner());
+                dto.setPlayers(rec.getPlayers());
+                dto.setRoundsPlayed(rec.getRoundsPlayed());
+                dto.setRoundCardStartAmount(rec.getRoundCardStartAmount());
+                dto.setStartedAt(rec.getStartedAt());
+                dto.setCompletedAt(rec.getCompletedAt());
+                return dto;
+            })
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
-
+import java.util.List; 
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
 import ch.uzh.ifi.hase.soprafs24.util.TokenUtils;
@@ -31,6 +31,10 @@ public class UserService {
         this.authService = authService;
     }
 
+    public User updateUser(User user) {
+        return userRepository.saveAndFlush(user);
+    }
+    
     // Public profile
     public User getPublicProfile(Long userId) {
         return userRepository.findById(userId)
@@ -222,4 +226,12 @@ public class UserService {
 
         return user;
     }
+
+    /**
+ * Return the top N users sorted by descending MMR.
+ */
+    public List<User> getTopPlayersByMmr(int count) {
+    // since we only need 10, you can directly call the repo method:
+    return userRepository.findTop10ByOrderByProfileMmrDesc();
+}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,8 @@ google.maps.api.key=AIzaSyBtsUV1ZJh2IjV062I5HQtdTRQokabjNzA
 %dev.spring.datasource.password=
 %dev.spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 %dev.spring.jpa.hibernate.ddl-auto=create-drop
+%dev.spring.cloud.gcp.sql.enabled=false
+%dev.spring.cloud.gcp.sql.jdbc.enabled=false
 
 # ───── PROD ─────
 # 1) Turn off H2 console completely

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,15 +3,20 @@ server.port=8080
 google.maps.api.key=AIzaSyBtsUV1ZJh2IjV062I5HQtdTRQokabjNzA
 
 # ───── DEV ─────
-%dev.spring.h2.console.enabled=true
-%dev.spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-%dev.spring.datasource.driver-class-name=org.h2.Driver
+%dev.spring.profiles.active=dev          
+%dev.spring.h2.console.enabled=true      
+%dev.spring.h2.console.path=/h2-console  
+
+%dev.spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL
 %dev.spring.datasource.username=sa
 %dev.spring.datasource.password=
 %dev.spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 %dev.spring.jpa.hibernate.ddl-auto=create-drop
+
+# disable GCP SQL in dev
 %dev.spring.cloud.gcp.sql.enabled=false
 %dev.spring.cloud.gcp.sql.jdbc.enabled=false
+
 
 # ───── PROD ─────
 # 1) Turn off H2 console completely

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,9 +13,7 @@ google.maps.api.key=AIzaSyBtsUV1ZJh2IjV062I5HQtdTRQokabjNzA
 %dev.spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 %dev.spring.jpa.hibernate.ddl-auto=create-drop
 
-# disable GCP SQL in dev
-%dev.spring.cloud.gcp.sql.enabled=false
-%dev.spring.cloud.gcp.sql.jdbc.enabled=false
+
 
 
 # ───── PROD ─────


### PR DESCRIPTION
### **Related Issues**
Closes #94, Closes #262

### Changes
Created new DTO classes LeaderboardDTO and LeaderboardEntryDTO to structure the top-10 leaderboard response, exposing each player’s username and MMR in the API (feature/add-leaderboard-and-win-streak).

Added findTop10ByOrderByProfileMmrDesc() to UserRepository and corresponding getTopPlayersByMmr(int) in UserService to fetch the highest-ranked players by MMR.

Exposed a new GET /leaderboard endpoint in StatsController that returns a LeaderboardDTO containing the top-10 entries.

Extended the UserProfile entity with a new winStreak field (initialized to 0) and provided its getter/setter to persist consecutive wins.

Added findTopByPlayers_IdOrderByCreationDateDesc(Long userId) to GameRepository to retrieve each user’s most recent game for stats.

Extended UserStatsDTO with winStreak, lastGamePlayers (List<String>), and lastGameWinner (String), along with their getters and setters.

Updated DTOMapper.toUserStatsDTO to map the new winStreak value and populate lastGamePlayers and lastGameWinner by querying the most recent game.

Enhanced GameService.endGame to increment or reset winStreak, update gamesPlayed and wins, and persist the modified User via a new updateUser(User) overload.

Added public User updateUser(User user) overload in UserService for internal profile persistence (used by game-end logic).

Configured application.properties for spring.jpa.hibernate.ddl-auto and SQL logging to support new entity fields and repository behavior.

Branch named feature/add-leaderboard-and-win-streak to reflect combined feature work.

### Additional Notes
This PR delivers two related features:

Leaderboard endpoint for clients to retrieve the top-10 users by MMR.

Win-streak tracking and most-recent-game breakdown in the existing stats endpoints.

The frontend team will need to adjust UI components to consume the new winStreak, lastGamePlayers, and lastGameWinner fields. 







