### PR TITLE
Test/stats and lobby

### DIFF
--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerAdditionalTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/LobbyControllerAdditionalTest.java
@@ -1,22 +1,22 @@
 package ch.uzh.ifi.hase.soprafs24.controller;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.server.ResponseStatusException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ch.uzh.ifi.hase.soprafs24.constant.LobbyConstants;
@@ -28,6 +28,12 @@ import ch.uzh.ifi.hase.soprafs24.rest.dto.LobbyResponseDTO;
 import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs24.service.AuthService;
 import ch.uzh.ifi.hase.soprafs24.service.LobbyService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @TestPropertySource(properties = "spring.cloud.gcp.sql.enabled=false")
 @WebMvcTest(LobbyController.class)
 public class LobbyControllerAdditionalTest {
@@ -94,29 +100,100 @@ public class LobbyControllerAdditionalTest {
     }
     
     @Test
+    public void getLobby_InvalidId_ReturnsNotFound() throws Exception {
+        when(lobbyService.getLobbyById(eq(99L)))
+            .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Lobby not found"));
+
+        mockMvc.perform(
+            get("/lobbies/99")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+    
+    @Test
     public void inviteToLobby_ValidRequest_ReturnsInviteResponse() throws Exception {
         // given
         InviteLobbyRequestDTO inviteDTO = new InviteLobbyRequestDTO();
         inviteDTO.setFriendId(2L);
         
-        // Create an instance of LobbyInviteResponseDTO with the correct fields
         LobbyInviteResponseDTO inviteResponseDTO = new LobbyInviteResponseDTO();
-        inviteResponseDTO.setInvitedFriend("friendUsername"); // This is what the actual DTO has
+        inviteResponseDTO.setInvitedFriend("friendUsername");
         inviteResponseDTO.setLobbyCode(dummyLobby.getLobbyCode());
         
         when(authService.getUserByToken(token)).thenReturn(dummyUser);
-        when(lobbyService.inviteToLobby(eq(10L), eq(dummyUser.getId()), Mockito.any(InviteLobbyRequestDTO.class)))
+        when(lobbyService.inviteToLobby(eq(10L), eq(dummyUser.getId()), any(InviteLobbyRequestDTO.class)))
             .thenReturn(inviteResponseDTO);
         
-        // when/then
         mockMvc.perform(
             post("/lobbies/10/invite")
                 .header("Authorization", token)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(inviteDTO)))
             .andExpect(status().isOk())
-            // Update assertions to match actual response structure
             .andExpect(jsonPath("$.invitedFriend").value("friendUsername"))
             .andExpect(jsonPath("$.lobbyCode").value(dummyLobby.getLobbyCode()));
+    }
+    
+    @Test
+    public void inviteToLobby_MissingAuthHeader_ReturnsBadRequest() throws Exception {
+        InviteLobbyRequestDTO inviteDTO = new InviteLobbyRequestDTO();
+        inviteDTO.setFriendId(2L);
+
+        mockMvc.perform(
+            post("/lobbies/10/invite")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inviteDTO)))
+            .andExpect(status().isBadRequest());
+    }
+    
+    @Test
+    public void inviteToLobby_InvalidToken_ReturnsUnauthorized() throws Exception {
+        String badToken = "Bearer invalid-token";
+        when(authService.getUserByToken(eq(badToken)))
+            .thenThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid or missing token"));
+
+        InviteLobbyRequestDTO inviteDTO = new InviteLobbyRequestDTO();
+        inviteDTO.setFriendId(2L);
+
+        mockMvc.perform(
+            post("/lobbies/10/invite")
+                .header("Authorization", badToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inviteDTO)))
+            .andExpect(status().isUnauthorized());
+    }
+    
+    @Test
+    public void inviteToLobby_NonHost_ReturnsForbidden() throws Exception {
+        when(authService.getUserByToken(token)).thenReturn(dummyUser);
+        when(lobbyService.inviteToLobby(eq(10L), eq(dummyUser.getId()), any(InviteLobbyRequestDTO.class)))
+            .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the host can invite players"));
+
+        InviteLobbyRequestDTO inviteDTO = new InviteLobbyRequestDTO();
+        inviteDTO.setFriendId(2L);
+
+        mockMvc.perform(
+            post("/lobbies/10/invite")
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inviteDTO)))
+            .andExpect(status().isForbidden());
+    }
+    
+    @Test
+    public void inviteToLobby_FriendNotFound_ReturnsNotFound() throws Exception {
+        when(authService.getUserByToken(token)).thenReturn(dummyUser);
+        when(lobbyService.inviteToLobby(eq(10L), eq(dummyUser.getId()), any(InviteLobbyRequestDTO.class)))
+            .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Friend not found"));
+
+        InviteLobbyRequestDTO inviteDTO = new InviteLobbyRequestDTO();
+        inviteDTO.setFriendId(999L);
+
+        mockMvc.perform(
+            post("/lobbies/10/invite")
+                .header("Authorization", token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(inviteDTO)))
+            .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION

- Extended **StatsControllerTest** with tests for:
  - 404 when user not found  
  - 401 on invalid token  
  - 400 when Authorization header is missing  
- Extended **LobbyControllerAdditionalTest** with tests for:
  - 404 for invalid lobby ID  
  - 400 when Authorization header is missing  
  - 401 on invalid token  
  - 403 when non-host user attempts to invite  
  - 404 when invited friend not found  
- Extended **GameControllerTest** with tests for:
  - 404 when player-token retrieval fails  
  - 503 when `roundCardService` is unavailable  
  - 503 when `actionCardService` is unavailable 

### Additional Notes

Please review these expanded error-handling scenarios and let me know if any more edge cases are needed.  
