### PR TITLE
update_wins_and_games_played, as well as tests therefor

### DIFF
--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceStatsTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceStatsTest.java
@@ -1,0 +1,101 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.entity.UserProfile;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs24.service.GameService;
+import ch.uzh.ifi.hase.soprafs24.service.GameService.GameState;
+import ch.uzh.ifi.hase.soprafs24.service.GameService.GameState.PlayerInfo;
+import ch.uzh.ifi.hase.soprafs24.service.GameService.GameStatus;
+import ch.uzh.ifi.hase.soprafs24.service.AuthService;
+import ch.uzh.ifi.hase.soprafs24.service.UserXpService;
+import ch.uzh.ifi.hase.soprafs24.service.GoogleMapsService;
+import ch.uzh.ifi.hase.soprafs24.service.GameRoundService;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+public class GameServiceStatsTest {
+
+    private static final Long GAME_ID = 123L;
+    private static final String WINNER_TOKEN = "winner";
+    private static final String LOSER_TOKEN  = "loser";
+
+    @Mock private GoogleMapsService googleMapsService;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+    @Mock private GameRoundService gameRoundService;
+    @Mock private AuthService authService;
+    @Mock private UserXpService userXpService;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks
+    private GameService gameService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void determineRoundWinner_incrementsGamesPlayedAndWins() {
+        // Arrange: set up GameState with two players and guesses
+        GameState state = new GameState();
+        state.setPlayerTokens(Arrays.asList(WINNER_TOKEN, LOSER_TOKEN));
+        state.setStatus(GameStatus.WAITING_FOR_GUESSES);
+        state.getPlayerGuesses().put(WINNER_TOKEN, 10);
+        state.getPlayerGuesses().put(LOSER_TOKEN, 20);
+        // ensure PlayerInfo entries exist
+        state.getPlayerInfo().put(WINNER_TOKEN, new PlayerInfo());
+        state.getPlayerInfo().put(LOSER_TOKEN, new PlayerInfo());
+
+        // inject into gameService
+        Map<Long, GameState> map = new ConcurrentHashMap<>();
+        map.put(GAME_ID, state);
+        ReflectionTestUtils.setField(gameService, "gameStates", map);
+
+        // prepare User stats
+        User winner = new User();
+        UserProfile wp = new UserProfile();
+        wp.setGamesPlayed(0);
+        wp.setWins(0);
+        winner.setProfile(wp);
+
+        User loser = new User();
+        UserProfile lp = new UserProfile();
+        lp.setGamesPlayed(5);
+        lp.setWins(1);
+        loser.setProfile(lp);
+
+        when(authService.getUserByToken(WINNER_TOKEN)).thenReturn(winner);
+        when(authService.getUserByToken(LOSER_TOKEN)).thenReturn(loser);
+
+        // Act
+        String result = gameService.determineRoundWinner(GAME_ID);
+
+        // Assert: correct winner returned
+        assertEquals(WINNER_TOKEN, result);
+
+        // Loser: gamesPlayed +1, wins unchanged
+        assertEquals(6, loser.getProfile().getGamesPlayed());
+        assertEquals(1, loser.getProfile().getWins());
+        verify(userRepository).save(loser);
+
+        // Winner: gamesPlayed +1, wins +1
+        assertEquals(1, winner.getProfile().getGamesPlayed());
+        assertEquals(1, winner.getProfile().getWins());
+        verify(userRepository).save(winner);
+    }
+}


### PR DESCRIPTION
Related Issues
Closes Task 262
Closes Task 320


!!!!! 

NOTE! THE COMMITS ARE ACCIDENTALLY ALL IN ONE, I'VE MESSAGED THE TA ABOUT THIS AND WILL FIX THAT WHEN I CAN. 

However, since we agreed to merge everything today, you can already merge it since the functionality works, HOWEVER, REMEMBER THAT THE COMMITS ARE NOT SEGMENTED:

!!!!!

Changes
Injected UserRepository into GameService via constructor for persisting stats

Added logic in endGame(...) to increment gamesPlayed for all participants and wins for the game winner

Created GameServiceStatsTest skeleton and implemented tests verifying that gamesPlayed and wins counters are updated correctly

Ensured existing functionality (XP awarding, messaging) remains untouched

Additional Notes
This branch (feature/update_wins_and_games_played) refactors only the server‐side game‐stat logic and associated tests; no UI code has been changed. For the same reason though, since it is so late to the deadline, and we agreed to be done by tonight, the UI cannot be changed thus any backend change is futile.

After merging pull and run ./gradlew test to confirm the new tests pass.