### PR TITLE
Feat/update wins and games played

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
@@ -597,24 +597,7 @@ public class GameService {
                 );
             }
 
-            for (String token : gameState.getPlayerInfo().keySet()) {
-                // skip winner here; we'll handle them below
-                if (token.equals(winnerToken)) continue;
-                User participant = authService.getUserByToken(token);
-                participant.getProfile().setGamesPlayed(
-                    participant.getProfile().getGamesPlayed() + 1
-                );
-                userRepository.save(participant);
-            }
             
-            // now handle the winner
-            winner.getProfile().setGamesPlayed(
-                winner.getProfile().getGamesPlayed() + 1
-            );
-            winner.getProfile().setWins(
-                winner.getProfile().getWins() + 1
-            );
-            userRepository.save(winner);
 
         
             return winnerToken;
@@ -722,6 +705,25 @@ public class GameService {
                 "You won the game!"
             )
         );
+
+        for (String token : gameState.getPlayerInfo().keySet()) {
+            // skip winner here; we'll handle them below
+            if (token.equals(winnerToken)) continue;
+            User participant = authService.getUserByToken(token);
+            participant.getProfile().setGamesPlayed(
+                participant.getProfile().getGamesPlayed() + 1
+            );
+            userRepository.save(participant);
+        }
+        
+        // now handle the winner
+        winner.getProfile().setGamesPlayed(
+            winner.getProfile().getGamesPlayed() + 1
+        );
+        winner.getProfile().setWins(
+            winner.getProfile().getWins() + 1
+        );
+        userRepository.save(winner);
 
         // 4) Broadcast game-winner to everyone
         messagingTemplate.convertAndSend(

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceStatsTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceStatsTest.java
@@ -87,10 +87,10 @@ public class GameServiceStatsTest {
         when(authService.getUserByToken(LOSER_TOKEN)).thenReturn(loser);
 
         // Act
-        String result = gameService.determineRoundWinner(GAME_ID);
+        gameService.endGame(GAME_ID, WINNER_TOKEN);
 
         // Assert: correct winner returned
-        assertEquals(WINNER_TOKEN, result);
+        // assertEquals(WINNER_TOKEN, result);
 
         // Loser: gamesPlayed +1, wins unchanged
         assertEquals(6, loser.getProfile().getGamesPlayed());

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceStatsTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceStatsTest.java
@@ -68,12 +68,16 @@ public class GameServiceStatsTest {
 
         // prepare User stats
         User winner = new User();
+        winner.setEmail("winner@example.com");
+        winner.setPassword("test");
         UserProfile wp = new UserProfile();
         wp.setGamesPlayed(0);
         wp.setWins(0);
         winner.setProfile(wp);
 
         User loser = new User();
+        loser.setEmail("loser@example.com");
+        loser.setPassword("test");
         UserProfile lp = new UserProfile();
         lp.setGamesPlayed(5);
         lp.setWins(1);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceStatsTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceStatsTest.java
@@ -1,0 +1,101 @@
+package ch.uzh.ifi.hase.soprafs24.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import ch.uzh.ifi.hase.soprafs24.entity.User;
+import ch.uzh.ifi.hase.soprafs24.entity.UserProfile;
+import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs24.service.GameService;
+import ch.uzh.ifi.hase.soprafs24.service.GameService.GameState;
+import ch.uzh.ifi.hase.soprafs24.service.GameService.GameState.PlayerInfo;
+import ch.uzh.ifi.hase.soprafs24.service.GameService.GameStatus;
+import ch.uzh.ifi.hase.soprafs24.service.AuthService;
+import ch.uzh.ifi.hase.soprafs24.service.UserXpService;
+import ch.uzh.ifi.hase.soprafs24.service.GoogleMapsService;
+import ch.uzh.ifi.hase.soprafs24.service.GameRoundService;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+public class GameServiceStatsTest {
+
+    private static final Long GAME_ID = 123L;
+    private static final String WINNER_TOKEN = "winner";
+    private static final String LOSER_TOKEN  = "loser";
+
+    @Mock private GoogleMapsService googleMapsService;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+    @Mock private GameRoundService gameRoundService;
+    @Mock private AuthService authService;
+    @Mock private UserXpService userXpService;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks
+    private GameService gameService;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void determineRoundWinner_incrementsGamesPlayedAndWins() {
+        // Arrange: set up GameState with two players and guesses
+        GameState state = new GameState();
+        state.setPlayerTokens(Arrays.asList(WINNER_TOKEN, LOSER_TOKEN));
+        state.setStatus(GameStatus.WAITING_FOR_GUESSES);
+        state.getPlayerGuesses().put(WINNER_TOKEN, 10);
+        state.getPlayerGuesses().put(LOSER_TOKEN, 20);
+        // ensure PlayerInfo entries exist
+        state.getPlayerInfo().put(WINNER_TOKEN, new PlayerInfo());
+        state.getPlayerInfo().put(LOSER_TOKEN, new PlayerInfo());
+
+        // inject into gameService
+        Map<Long, GameState> map = new ConcurrentHashMap<>();
+        map.put(GAME_ID, state);
+        ReflectionTestUtils.setField(gameService, "gameStates", map);
+
+        // prepare User stats
+        User winner = new User();
+        UserProfile wp = new UserProfile();
+        wp.setGamesPlayed(0);
+        wp.setWins(0);
+        winner.setProfile(wp);
+
+        User loser = new User();
+        UserProfile lp = new UserProfile();
+        lp.setGamesPlayed(5);
+        lp.setWins(1);
+        loser.setProfile(lp);
+
+        when(authService.getUserByToken(WINNER_TOKEN)).thenReturn(winner);
+        when(authService.getUserByToken(LOSER_TOKEN)).thenReturn(loser);
+
+        // Act
+        String result = gameService.determineRoundWinner(GAME_ID);
+
+        // Assert: correct winner returned
+        assertEquals(WINNER_TOKEN, result);
+
+        // Loser: gamesPlayed +1, wins unchanged
+        assertEquals(6, loser.getProfile().getGamesPlayed());
+        assertEquals(1, loser.getProfile().getWins());
+        verify(userRepository).save(loser);
+
+        // Winner: gamesPlayed +1, wins +1
+        assertEquals(1, winner.getProfile().getGamesPlayed());
+        assertEquals(1, winner.getProfile().getWins());
+        verify(userRepository).save(winner);
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/GameServiceTest.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
+import ch.uzh.ifi.hase.soprafs24.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 import ch.uzh.ifi.hase.soprafs24.entity.UserProfile;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.game.RoundCardDTO;
@@ -84,13 +85,36 @@ public class GameServiceTest {
         playerTokens = Arrays.asList(USER1_TOKEN, USER2_TOKEN);
 
         user1 = new User();
-        ReflectionTestUtils.setField(user1, "id", 1L);
-        user1.setToken(USER1_TOKEN);
-        UserProfile p1 = new UserProfile();
-        p1.setUsername("User One");
-        user1.setProfile(p1);
+    user1.setToken(USER1_TOKEN);
+    user1.setEmail("user1@example.com");
+    user1.setPassword("password1");
+    user1.setStatus(UserStatus.ONLINE);
+    user1.setUsername("user1");
+    UserProfile profile1 = new UserProfile();
+    profile1.setUsername("user1");      // non-nullable
+    profile1.setXp(0);                  // @Column(nullable = false)
+    profile1.setPoints(0);              // @Column(nullable = false)
+    profile1.setGamesPlayed(0);         // @Column(nullable = false)
+    profile1.setWins(0);                // @Column(nullable = false)
+    profile1.setStatsPublic(true);      // @Column(nullable = false)
+    user1.setProfile(profile1);
 
-        user2 = new User();
+    user2 = new User();
+    user2.setToken(USER2_TOKEN);
+    user2.setEmail("user2@example.com");
+    user2.setPassword("password2");
+    user2.setStatus(UserStatus.ONLINE);
+    user2.setUsername("user2");
+    UserProfile profile2 = new UserProfile();
+    profile2.setUsername("user2");
+    profile2.setXp(0);
+    profile2.setPoints(0);
+    profile2.setGamesPlayed(0);
+    profile2.setWins(0);
+    profile2.setStatsPublic(true);
+    user2.setProfile(profile2);
+
+
         ReflectionTestUtils.setField(user2, "id", 2L);
         user2.setToken(USER2_TOKEN);
         UserProfile p2 = new UserProfile();


### PR DESCRIPTION
Related Issues
Closes Task 262
Closes Task 320

!!!!!

NOTE! THE COMMITS ARE ACCIDENTALLY ALL IN ONE, I'VE MESSAGED THE TA ABOUT THIS AND WILL FIX THAT WHEN I CAN.

However, since we agreed to merge everything today, you can already merge it since the functionality works, HOWEVER, REMEMBER THAT THE COMMITS ARE NOT SEGMENTED:

!!!!!

Changes
Injected UserRepository into GameService via constructor for persisting stats

Added logic in endGame(...) to increment gamesPlayed for all participants and wins for the game winner

Created GameServiceStatsTest skeleton and implemented tests verifying that gamesPlayed and wins counters are updated correctly

Ensured existing functionality (XP awarding, messaging) remains untouched

Additional Notes
This branch (feature/update_wins_and_games_played) refactors only the server‐side game‐stat logic and associated tests; no UI code has been changed. For the same reason though, since it is so late to the deadline, and we agreed to be done by tonight, the UI cannot be changed thus any backend change is futile.

After merging pull and run ./gradlew test to confirm the new tests pass.